### PR TITLE
Add Plex trivia webapp template

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+FROM python:3.11-slim
+WORKDIR /app
+COPY requirements.txt requirements.txt
+RUN pip install --no-cache-dir -r requirements.txt
+COPY . .
+ENV FLASK_APP=app:create_app
+ENV FLASK_RUN_HOST=0.0.0.0
+EXPOSE 5000
+CMD ["flask", "run"]
+

--- a/README.md
+++ b/README.md
@@ -1,2 +1,49 @@
-# media-server-trivia
-An unraid application that quizzes you on your own media library
+# Media Server Trivia
+
+A template for an Unraid-ready application that turns your Plex library into a trivia game. This project exposes a simple Flask web interface that connects to your Plex server and generates trivia questions from your media.
+
+## Features
+- Connects to a Plex server via API token
+- Lists your movies and TV shows
+- Generates a random trivia question from your library
+- Dockerized for easy deployment on Unraid or any Docker host
+
+## Requirements
+- Python 3.11 (for development) or Docker
+- A Plex API token and the base URL of your Plex server
+
+## Configuration
+The application reads two environment variables:
+
+```
+PLEX_BASE_URL=<http://your.plex.ip:32400>
+PLEX_TOKEN=<your_plex_token>
+```
+
+These can be supplied in `docker-compose.yml` or directly in your environment.
+
+## Running with Docker
+
+```
+docker compose up --build
+```
+
+The web interface will be available on `http://localhost:8080` by default.
+
+## Development
+
+Install dependencies and run the Flask development server:
+
+```
+python -m venv venv
+source venv/bin/activate
+pip install -r requirements.txt
+export PLEX_BASE_URL=http://your.plex.ip:32400
+export PLEX_TOKEN=your_token
+flask --app app:create_app run
+```
+
+## License
+
+This project is licensed under the MIT License.
+

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,0 +1,18 @@
+from flask import Flask
+import os
+from .plex_service import PlexService
+from .routes import init_routes
+
+
+def create_app():
+    app = Flask(__name__)
+
+    plex_base_url = os.getenv("PLEX_BASE_URL")
+    plex_token = os.getenv("PLEX_TOKEN")
+
+    plex_service = PlexService(base_url=plex_base_url, token=plex_token)
+
+    init_routes(app, plex_service)
+
+    return app
+

--- a/app/plex_service.py
+++ b/app/plex_service.py
@@ -1,0 +1,27 @@
+from plexapi.server import PlexServer
+
+
+class PlexService:
+    """Wrapper around the Plex API for retrieving media."""
+
+    def __init__(self, base_url: str | None, token: str | None):
+        self.base_url = base_url
+        self.token = token
+        self.server = None
+        if base_url and token:
+            try:
+                self.server = PlexServer(base_url, token)
+            except Exception:
+                # Fail silently; the routes will handle missing connection
+                self.server = None
+
+    def get_movies(self):
+        if not self.server:
+            return []
+        return [movie.title for movie in self.server.library.section('Movies').all()]
+
+    def get_shows(self):
+        if not self.server:
+            return []
+        return [show.title for show in self.server.library.section('TV Shows').all()]
+

--- a/app/routes.py
+++ b/app/routes.py
@@ -1,0 +1,23 @@
+from flask import Blueprint, render_template, jsonify
+from .trivia import TriviaEngine
+
+
+def init_routes(app, plex_service):
+    bp = Blueprint('main', __name__)
+    trivia = TriviaEngine(plex_service)
+
+    @bp.route('/')
+    def index():
+        movies = plex_service.get_movies()
+        shows = plex_service.get_shows()
+        return render_template('index.html', movies=movies, shows=shows)
+
+    @bp.route('/api/trivia')
+    def api_trivia():
+        q = trivia.random_question()
+        if not q:
+            return jsonify({'error': 'No media found'}), 404
+        return jsonify(q)
+
+    app.register_blueprint(bp)
+

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -1,0 +1,21 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Plex Trivia</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
+  </head>
+  <body class="bg-light">
+    <nav class="navbar navbar-dark bg-dark mb-4">
+      <div class="container-fluid">
+        <span class="navbar-brand mb-0 h1">Plex Trivia</span>
+      </div>
+    </nav>
+    <div class="container">
+      {% block content %}{% endblock %}
+    </div>
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
+  </body>
+</html>
+

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -1,0 +1,38 @@
+{% extends 'base.html' %}
+
+{% block content %}
+<h2>Your Movies</h2>
+<ul class="list-group mb-4">
+  {% for movie in movies %}
+  <li class="list-group-item">{{ movie }}</li>
+  {% else %}
+  <li class="list-group-item">No movies found.</li>
+  {% endfor %}
+</ul>
+
+<h2>Your TV Shows</h2>
+<ul class="list-group mb-4">
+  {% for show in shows %}
+  <li class="list-group-item">{{ show }}</li>
+  {% else %}
+  <li class="list-group-item">No shows found.</li>
+  {% endfor %}
+</ul>
+
+<button id="triviaBtn" class="btn btn-primary">Get Random Trivia</button>
+<div id="trivia" class="mt-3"></div>
+
+<script>
+  document.getElementById('triviaBtn').addEventListener('click', async () => {
+    const res = await fetch('/api/trivia');
+    const data = await res.json();
+    const div = document.getElementById('trivia');
+    if (data.question) {
+      div.innerHTML = `<div class='alert alert-info'><strong>Q:</strong> ${data.question}<br><strong>A:</strong> ${data.answer}</div>`;
+    } else {
+      div.innerHTML = `<div class='alert alert-warning'>${data.error}</div>`;
+    }
+  });
+</script>
+{% endblock %}
+

--- a/app/trivia.py
+++ b/app/trivia.py
@@ -1,0 +1,17 @@
+import random
+
+
+class TriviaEngine:
+    """Generates trivia questions from Plex media."""
+
+    def __init__(self, plex_service):
+        self.plex = plex_service
+
+    def random_question(self):
+        movies = self.plex.get_movies()
+        if not movies:
+            return None
+        movie = random.choice(movies)
+        question = f"Which movie features '{movie}'?"
+        return {"question": question, "answer": movie}
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,10 @@
+version: '3'
+services:
+  trivia:
+    build: .
+    ports:
+      - "8080:5000"
+    environment:
+      - PLEX_BASE_URL=http://your.plex.ip:32400
+      - PLEX_TOKEN=your_token
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+Flask
+plexapi
+


### PR DESCRIPTION
## Summary
- add basic Flask app that talks to Plex
- build minimal UI with Bootstrap
- provide Dockerfile and docker-compose.yml
- document setup and usage in README

## Testing
- `python -m compileall app`

------
https://chatgpt.com/codex/tasks/task_e_6854665141a48331b4e81375b2e68892