### PR TITLE
Add dashboard layout with sidebar

### DIFF
--- a/app/static/style.css
+++ b/app/static/style.css
@@ -1,0 +1,35 @@
+/* Custom styles for Plex Trivia */
+body {
+    font-family: "Segoe UI", Tahoma, Geneva, Verdana, sans-serif;
+}
+
+.sidebar {
+    min-height: 100vh;
+    border-right: 1px solid #dee2e6;
+    width: 100%;
+}
+
+@media (min-width: 992px) {
+    .sidebar {
+        flex: 0 0 20%;
+        max-width: 20%;
+    }
+}
+
+.sidebar .nav-link {
+    color: #333;
+    transition: color 0.2s ease-in-out;
+}
+
+.sidebar .nav-link:hover {
+    color: #0d6efd;
+}
+
+#trivia {
+    transition: opacity 0.3s ease-in-out;
+    opacity: 0;
+}
+
+#trivia.show {
+    opacity: 1;
+}

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -5,6 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>Plex Trivia</title>
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link href="{{ url_for('static', filename='style.css') }}" rel="stylesheet">
   </head>
   <body class="bg-light">
     <nav class="navbar navbar-dark bg-dark mb-4">

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -1,27 +1,66 @@
 {% extends 'base.html' %}
 
 {% block content %}
-<h2>Your Movies</h2>
-<ul class="list-group mb-4">
-  {% for movie in movies %}
-  <li class="list-group-item">{{ movie }}</li>
-  {% else %}
-  <li class="list-group-item">No movies found.</li>
-  {% endfor %}
-</ul>
-
-<h2>Your TV Shows</h2>
-<ul class="list-group mb-4">
-  {% for show in shows %}
-  <li class="list-group-item">{{ show }}</li>
-  {% else %}
-  <li class="list-group-item">No shows found.</li>
-  {% endfor %}
-</ul>
-
-<button id="triviaBtn" class="btn btn-primary">Get Random Trivia</button>
-<div id="trivia" class="mt-3"></div>
-
+<div class="row">
+  <div class="col-12 col-md-3 col-lg-2 sidebar bg-white p-4">
+    <div class="text-center mb-4">
+      <img src="https://via.placeholder.com/80" class="rounded-circle mb-2" alt="Profile">
+      <h5 class="fw-bold">Guest</h5>
+    </div>
+    <hr>
+    <h6 class="text-uppercase fw-bold small mb-3">Settings</h6>
+    <ul class="nav flex-column mb-4">
+      <li class="nav-item"><a class="nav-link" href="#">Profile</a></li>
+      <li class="nav-item"><a class="nav-link" href="#">Account</a></li>
+    </ul>
+    <h6 class="text-uppercase fw-bold small mb-3">Categories</h6>
+    <ul class="nav flex-column">
+      <li class="nav-item"><a class="nav-link" href="#">Movie Trivia</a></li>
+      <li class="nav-item"><a class="nav-link" href="#">TV Trivia</a></li>
+      <li class="nav-item"><a class="nav-link" href="#">Miscellaneous</a></li>
+    </ul>
+  </div>
+  <div class="col-12 col-md-9 col-lg-10 p-4">
+    <div class="row g-4">
+      <div class="col-12">
+        <div class="p-5 bg-primary text-white rounded-3 shadow-sm">
+          <h2 class="display-6">Welcome to Plex Trivia!</h2>
+          <p class="lead">Challenge yourself with questions from your own library.</p>
+          <button id="triviaBtn" class="btn btn-light btn-lg mt-3">Get Random Trivia</button>
+          <div id="trivia" class="mt-3"></div>
+        </div>
+      </div>
+      <div class="col-md-6">
+        <div class="card h-100 shadow-sm">
+          <div class="card-body">
+            <h5 class="card-title fw-bold">Your Movies</h5>
+            <ul class="list-group list-group-flush">
+              {% for movie in movies %}
+              <li class="list-group-item">{{ movie }}</li>
+              {% else %}
+              <li class="list-group-item">No movies found.</li>
+              {% endfor %}
+            </ul>
+          </div>
+        </div>
+      </div>
+      <div class="col-md-6">
+        <div class="card h-100 shadow-sm">
+          <div class="card-body">
+            <h5 class="card-title fw-bold">Your TV Shows</h5>
+            <ul class="list-group list-group-flush">
+              {% for show in shows %}
+              <li class="list-group-item">{{ show }}</li>
+              {% else %}
+              <li class="list-group-item">No shows found.</li>
+              {% endfor %}
+            </ul>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
 <script>
   document.getElementById('triviaBtn').addEventListener('click', async () => {
     const res = await fetch('/api/trivia');
@@ -32,7 +71,7 @@
     } else {
       div.innerHTML = `<div class='alert alert-warning'>${data.error}</div>`;
     }
+    div.classList.add('show');
   });
 </script>
 {% endblock %}
-


### PR DESCRIPTION
## Summary
- implement custom stylesheet for typography and sidebar layout
- load the stylesheet in the base template
- redesign the index page into a dashboard with a left sidebar and main content area

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68547012c3e483319ffd3f66748dd200