### PR TITLE
Add modern dashboard interface

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -1,9 +1,11 @@
 from flask import Blueprint, Flask, render_template, jsonify
 from .plex_service import PlexService
+from .trivia import TriviaEngine
 
 
 def init_routes(app: Flask, plex_service: PlexService):
     bp = Blueprint("main", __name__)
+    trivia_engine = TriviaEngine(plex_service)
 
     @bp.route("/")
     def index():
@@ -12,11 +14,11 @@ def init_routes(app: Flask, plex_service: PlexService):
         shows = plex_service.get_shows()
         return render_template("index.html", movies=movies, shows=shows)
 
-    # @bp.route("/api/trivia")
-    # def api_trivia():
-    #     q = trivia.random_question()
-    #     if not q:
-    #         return jsonify({"error": "No media found"}), 404
-    #     return jsonify(q)
+    @bp.route("/api/trivia")
+    def api_trivia():
+        q = trivia_engine.random_question()
+        if not q:
+            return jsonify({"error": "No media found"})
+        return jsonify(q)
 
     app.register_blueprint(bp)

--- a/app/static/css/main.css
+++ b/app/static/css/main.css
@@ -1,0 +1,44 @@
+body {
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+}
+
+#sidebar {
+  width: 100%;
+  min-height: 100vh;
+}
+
+@media (min-width: 768px) {
+  #sidebar {
+    width: 20%;
+  }
+}
+
+#sidebar h2 {
+  font-weight: 700;
+  font-size: 1.5rem;
+}
+
+#sidebar .nav-link {
+  color: #ffffff;
+  margin: 0.25rem 0;
+}
+
+#sidebar .nav-link:hover {
+  text-decoration: underline;
+  color: #ffffff;
+}
+
+main {
+  flex-grow: 1;
+  padding: 2rem;
+  background-color: #f8f9fa;
+}
+
+.card {
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.card:hover {
+  transform: translateY(-4px);
+  box-shadow: 0 0.5rem 1rem rgba(0,0,0,0.15);
+}

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -5,17 +5,41 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>Plex Trivia</title>
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link rel="stylesheet" href="{{ url_for('static', filename='css/main.css') }}">
   </head>
   <body class="bg-light">
-    <nav class="navbar navbar-dark bg-dark mb-4">
-      <div class="container-fluid">
-        <span class="navbar-brand mb-0 h1">Plex Trivia</span>
-      </div>
-    </nav>
-    <div class="container">
-      {% block content %}{% endblock %}
+    <div class="d-flex">
+      <nav id="sidebar" class="bg-dark text-white p-3">
+        <h2 class="mb-4">Plex Trivia</h2>
+        <div class="mb-4">
+          <h5>Profile</h5>
+          <p class="mb-1">Guest</p>
+        </div>
+        <div class="mb-4">
+          <h5>Settings</h5>
+          <a href="#" class="nav-link">Account</a>
+          <a href="#" class="nav-link">Preferences</a>
+        </div>
+        <div>
+          <h5>Categories</h5>
+          <a href="#" class="nav-link">Movie Trivia</a>
+          <a href="#" class="nav-link">TV Trivia</a>
+          <a href="#" class="nav-link">Miscellaneous</a>
+        </div>
+      </nav>
+      <main class="flex-grow-1">
+        {% block content %}{% endblock %}
+      </main>
     </div>
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
+    <script>
+      document.addEventListener('DOMContentLoaded', () => {
+        const cards = document.querySelectorAll('.card');
+        cards.forEach(card => {
+          card.classList.add('opacity-0');
+          setTimeout(() => card.classList.add('opacity-100'), 100);
+        });
+      });
+    </script>
   </body>
 </html>
-

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -1,26 +1,58 @@
 {% extends 'base.html' %}
 
 {% block content %}
-<h2>Your Movies</h2>
-<ul class="list-group mb-4">
-  {% for movie in movies %}
-  <li class="list-group-item">{{ movie }}</li>
-  {% else %}
-  <li class="list-group-item">No movies found.</li>
-  {% endfor %}
-</ul>
-
-<h2>Your TV Shows</h2>
-<ul class="list-group mb-4">
-  {% for show in shows %}
-  <li class="list-group-item">{{ show }}</li>
-  {% else %}
-  <li class="list-group-item">No shows found.</li>
-  {% endfor %}
-</ul>
-
-<button id="triviaBtn" class="btn btn-primary">Get Random Trivia</button>
-<div id="trivia" class="mt-3"></div>
+<div class="container-fluid">
+  <div class="row g-4">
+    <div class="col-12">
+      <h1 class="display-6 fw-bold">Dashboard</h1>
+    </div>
+    <div class="col-12 col-md-6 col-xl-4">
+      <div class="card shadow-sm h-100">
+        <div class="card-body">
+          <h5 class="card-title">Random Trivia</h5>
+          <p class="card-text" id="trivia">Click the button to load trivia.</p>
+          <button id="triviaBtn" class="btn btn-primary">Get Random Trivia</button>
+        </div>
+      </div>
+    </div>
+    <div class="col-12 col-md-6 col-xl-4">
+      <div class="card shadow-sm h-100">
+        <div class="card-body">
+          <h5 class="card-title">Movies</h5>
+          <ul class="list-group list-group-flush">
+            {% for movie in movies %}
+            <li class="list-group-item">{{ movie }}</li>
+            {% else %}
+            <li class="list-group-item">No movies found.</li>
+            {% endfor %}
+          </ul>
+        </div>
+      </div>
+    </div>
+    <div class="col-12 col-md-6 col-xl-4">
+      <div class="card shadow-sm h-100">
+        <div class="card-body">
+          <h5 class="card-title">TV Shows</h5>
+          <ul class="list-group list-group-flush">
+            {% for show in shows %}
+            <li class="list-group-item">{{ show }}</li>
+            {% else %}
+            <li class="list-group-item">No shows found.</li>
+            {% endfor %}
+          </ul>
+        </div>
+      </div>
+    </div>
+    <div class="col-12 col-md-6 col-xl-4">
+      <div class="card shadow-sm h-100">
+        <div class="card-body">
+          <h5 class="card-title">Leaderboard</h5>
+          <p class="card-text">Coming soon...</p>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
 
 <script>
   document.getElementById('triviaBtn').addEventListener('click', async () => {
@@ -28,11 +60,10 @@
     const data = await res.json();
     const div = document.getElementById('trivia');
     if (data.question) {
-      div.innerHTML = `<div class='alert alert-info'><strong>Q:</strong> ${data.question}<br><strong>A:</strong> ${data.answer}</div>`;
+      div.innerHTML = `<strong>Q:</strong> ${data.question}<br><strong>A:</strong> ${data.answer}`;
     } else {
-      div.innerHTML = `<div class='alert alert-warning'>${data.error}</div>`;
+      div.innerHTML = data.error;
     }
   });
 </script>
 {% endblock %}
-


### PR DESCRIPTION
## Summary
- create sidebar layout with categories and profile space
- add dashboard widgets for movies, shows, and trivia
- style with custom CSS and subtle hover animations
- implement trivia API route

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68547012c3e483319ffd3f66748dd200