### PR TITLE
Revamp dashboard UI

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -1,9 +1,11 @@
 from flask import Blueprint, Flask, render_template, jsonify
 from .plex_service import PlexService
+from .trivia import TriviaEngine
 
 
 def init_routes(app: Flask, plex_service: PlexService):
     bp = Blueprint("main", __name__)
+    trivia = TriviaEngine(plex_service)
 
     @bp.route("/")
     def index():
@@ -12,11 +14,11 @@ def init_routes(app: Flask, plex_service: PlexService):
         shows = plex_service.get_shows()
         return render_template("index.html", movies=movies, shows=shows)
 
-    # @bp.route("/api/trivia")
-    # def api_trivia():
-    #     q = trivia.random_question()
-    #     if not q:
-    #         return jsonify({"error": "No media found"}), 404
-    #     return jsonify(q)
+    @bp.route("/api/trivia")
+    def api_trivia():
+        q = trivia.random_question()
+        if not q:
+            return jsonify({"error": "No media found"}), 404
+        return jsonify(q)
 
     app.register_blueprint(bp)

--- a/app/static/style.css
+++ b/app/static/style.css
@@ -1,0 +1,28 @@
+body {
+  font-family: "Segoe UI", Tahoma, Geneva, Verdana, sans-serif;
+}
+
+.sidebar {
+  background-color: #f8f9fa;
+  min-height: 100vh;
+  border-right: 1px solid #dee2e6;
+}
+
+.sidebar .nav-link {
+  color: #333;
+  font-weight: 500;
+}
+
+.sidebar .nav-link:hover {
+  background-color: #e9ecef;
+  transition: background-color 0.3s ease;
+}
+
+.card-hover {
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.card-hover:hover {
+  transform: translateY(-3px);
+  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
+}

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -5,6 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>Plex Trivia</title>
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}">
   </head>
   <body class="bg-light">
     <nav class="navbar navbar-dark bg-dark mb-4">
@@ -12,8 +13,28 @@
         <span class="navbar-brand mb-0 h1">Plex Trivia</span>
       </div>
     </nav>
-    <div class="container">
-      {% block content %}{% endblock %}
+    <div class="container-fluid">
+      <div class="row flex-nowrap">
+        <aside class="sidebar col-12 col-md-3 col-lg-2 p-3">
+          <div class="text-center mb-4">
+            <img src="https://via.placeholder.com/80" class="rounded-circle mb-2" alt="Profile picture">
+            <h5 class="fw-bold">Guest</h5>
+          </div>
+          <ul class="nav flex-column mb-4">
+            <li class="nav-item"><a class="nav-link" href="#">Profile</a></li>
+            <li class="nav-item"><a class="nav-link" href="#">Settings</a></li>
+          </ul>
+          <h6 class="text-uppercase text-muted">Categories</h6>
+          <ul class="nav flex-column">
+            <li class="nav-item"><a class="nav-link" href="#">Movie Trivia</a></li>
+            <li class="nav-item"><a class="nav-link" href="#">TV Trivia</a></li>
+            <li class="nav-item"><a class="nav-link" href="#">Miscellaneous</a></li>
+          </ul>
+        </aside>
+        <main class="col py-4">
+          {% block content %}{% endblock %}
+        </main>
+      </div>
     </div>
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
   </body>

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -1,26 +1,35 @@
 {% extends 'base.html' %}
 
 {% block content %}
-<h2>Your Movies</h2>
-<ul class="list-group mb-4">
-  {% for movie in movies %}
-  <li class="list-group-item">{{ movie }}</li>
-  {% else %}
-  <li class="list-group-item">No movies found.</li>
-  {% endfor %}
-</ul>
-
-<h2>Your TV Shows</h2>
-<ul class="list-group mb-4">
-  {% for show in shows %}
-  <li class="list-group-item">{{ show }}</li>
-  {% else %}
-  <li class="list-group-item">No shows found.</li>
-  {% endfor %}
-</ul>
-
-<button id="triviaBtn" class="btn btn-primary">Get Random Trivia</button>
-<div id="trivia" class="mt-3"></div>
+<h1 class="mb-4">Welcome to Plex Trivia</h1>
+<div class="row g-4">
+  <div class="col-12 col-md-6 col-lg-4">
+    <div class="card card-hover h-100">
+      <div class="card-body">
+        <h5 class="card-title">Leaderboard</h5>
+        <p class="card-text">Top players will appear here.</p>
+      </div>
+    </div>
+  </div>
+  <div class="col-12 col-md-6 col-lg-4">
+    <div class="card card-hover h-100">
+      <div class="card-body">
+        <h5 class="card-title">Stats</h5>
+        <p class="card-text">Your trivia statistics will be displayed.</p>
+      </div>
+    </div>
+  </div>
+  <div class="col-12 col-md-6 col-lg-4">
+    <div class="card card-hover h-100">
+      <div class="card-body">
+        <h5 class="card-title">Random Trivia</h5>
+        <p class="card-text">Test your knowledge with a quick question.</p>
+        <button id="triviaBtn" class="btn btn-primary mt-2">Get Random Trivia</button>
+        <div id="trivia" class="mt-3"></div>
+      </div>
+    </div>
+  </div>
+</div>
 
 <script>
   document.getElementById('triviaBtn').addEventListener('click', async () => {
@@ -35,4 +44,3 @@
   });
 </script>
 {% endblock %}
-


### PR DESCRIPTION
## Summary
- add TriviaEngine to routes and expose /api/trivia endpoint
- restructure base layout with sidebar and main content area
- design a dashboard page with leaderboard, stats, and trivia widget
- style the app with a custom stylesheet

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python -m unittest discover` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_68547012c3e483319ffd3f66748dd200