### PR TITLE
Add interactive trivia games

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,10 @@ A template for an Unraid-ready application that turns your Plex library into a t
 ## Features
 - Connects to a Plex server via API token
 - Lists your movies and TV shows
-- Generates a random trivia question from your library
+- Generates several trivia games from your library:
+  - Cast Reveal Game
+  - Guess the Release Year
+  - Poster Reveal Challenge
 - Dockerized for easy deployment on Unraid or any Docker host
 
 ## Requirements

--- a/app/routes.py
+++ b/app/routes.py
@@ -9,19 +9,34 @@ def init_routes(app: Flask, plex_service: PlexService):
 
     @bp.route("/")
     def index():
-        print("Index route called")
         movies = plex_service.get_movies()
         shows = plex_service.get_shows()
-
-        # Print all properties of the first movie
-        print(movies[0])
-        print(movies[0].guids)
-
         return render_template("index.html", movies=movies, shows=shows)
 
     @bp.route("/api/trivia")
     def api_trivia():
         q = trivia.random_question()
+        if not q:
+            return jsonify({"error": "No media found"}), 404
+        return jsonify(q)
+
+    @bp.route("/api/trivia/cast")
+    def api_trivia_cast():
+        q = trivia.cast_reveal()
+        if not q:
+            return jsonify({"error": "No media found"}), 404
+        return jsonify(q)
+
+    @bp.route("/api/trivia/year")
+    def api_trivia_year():
+        q = trivia.guess_year()
+        if not q:
+            return jsonify({"error": "No media found"}), 404
+        return jsonify(q)
+
+    @bp.route("/api/trivia/poster")
+    def api_trivia_poster():
+        q = trivia.poster_reveal()
         if not q:
             return jsonify({"error": "No media found"}), 404
         return jsonify(q)

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -6,38 +6,104 @@
   <div class="col-12 col-md-6 col-lg-4">
     <div class="card card-hover h-100">
       <div class="card-body">
-        <h5 class="card-title">Leaderboard</h5>
-        <p class="card-text">Top players will appear here.</p>
+        <h5 class="card-title">Cast Reveal Game</h5>
+        <p class="card-text">Guess the movie as cast members are revealed.</p>
+        <button id="castBtn" class="btn btn-primary mt-2">Start</button>
+        <div id="castGame" class="mt-3"></div>
       </div>
     </div>
   </div>
   <div class="col-12 col-md-6 col-lg-4">
     <div class="card card-hover h-100">
       <div class="card-body">
-        <h5 class="card-title">Stats</h5>
-        <p class="card-text">Your trivia statistics will be displayed.</p>
+        <h5 class="card-title">Guess the Year</h5>
+        <p class="card-text">How well do you know release dates?</p>
+        <button id="yearBtn" class="btn btn-primary mt-2">New Question</button>
+        <div id="yearGame" class="mt-3"></div>
       </div>
     </div>
   </div>
   <div class="col-12 col-md-6 col-lg-4">
     <div class="card card-hover h-100">
       <div class="card-body">
-        <h5 class="card-title">Random Trivia</h5>
-        <p class="card-text">Test your knowledge with a quick question.</p>
-        <button id="triviaBtn" class="btn btn-primary mt-2">Get Random Trivia</button>
-        <div id="trivia" class="mt-3"></div>
+        <h5 class="card-title">Poster Reveal</h5>
+        <p class="card-text">The image becomes clearer each round.</p>
+        <button id="posterBtn" class="btn btn-primary mt-2">Reveal Poster</button>
+        <div id="posterGame" class="mt-3 text-center"></div>
       </div>
     </div>
   </div>
 </div>
 
 <script>
-  document.getElementById('triviaBtn').addEventListener('click', async () => {
-    const res = await fetch('/api/trivia');
+  document.getElementById('castBtn').addEventListener('click', async () => {
+    const res = await fetch('/api/trivia/cast');
     const data = await res.json();
-    const div = document.getElementById('trivia');
-    if (data.question) {
-      div.innerHTML = `<div class='alert alert-info'><strong>Q:</strong> ${data.question}<br><strong>A:</strong> ${data.answer}</div>`;
+    const div = document.getElementById('castGame');
+    if (data.cast) {
+      let index = 1;
+      div.innerHTML = `<div id='castList'></div><button id='revealCast' class='btn btn-sm btn-secondary mt-2'>Reveal Next</button>`;
+      const castList = document.getElementById('castList');
+      castList.innerHTML = `<span class='badge bg-info me-1'>${data.cast[0]}</span>`;
+      document.getElementById('revealCast').addEventListener('click', () => {
+        if (index < data.cast.length) {
+          castList.innerHTML += `<span class='badge bg-info me-1'>${data.cast[index]}</span>`;
+          index++;
+        } else {
+          document.getElementById('revealCast').disabled = true;
+          div.innerHTML += `<div class='mt-2 alert alert-primary'>Answer: ${data.title}</div>`;
+        }
+      });
+    } else {
+      div.innerHTML = `<div class='alert alert-warning'>${data.error}</div>`;
+    }
+  });
+
+  document.getElementById('yearBtn').addEventListener('click', async () => {
+    const res = await fetch('/api/trivia/year');
+    const data = await res.json();
+    const div = document.getElementById('yearGame');
+    if (data.title) {
+      div.innerHTML = `What year did <strong>${data.title}</strong> release? <input id='yearInput' class='form-control form-control-sm mt-2' placeholder='Enter year'><button id='yearGuess' class='btn btn-sm btn-secondary mt-2'>Guess</button><div id='yearAnswer' class='mt-2'></div>`;
+      document.getElementById('yearGuess').addEventListener('click', () => {
+        const guess = parseInt(document.getElementById('yearInput').value);
+        const ans = document.getElementById('yearAnswer');
+        if (guess === data.year) {
+          ans.innerHTML = `<span class='text-success'>Correct!</span>`;
+        } else {
+          ans.innerHTML = `<span class='text-danger'>Nope, it was ${data.year}</span>`;
+        }
+      });
+    } else {
+      div.innerHTML = `<div class='alert alert-warning'>${data.error}</div>`;
+    }
+  });
+
+  document.getElementById('posterBtn').addEventListener('click', async () => {
+    const res = await fetch('/api/trivia/poster');
+    const data = await res.json();
+    const div = document.getElementById('posterGame');
+    if (data.poster) {
+      let blur = 15;
+      const words = data.summary.split(' ');
+      let count = 3;
+      div.innerHTML = `<img id='posterImg' src='${data.poster}' style='max-width:100%;filter:blur(${blur}px);'><p id='posterSummary' class='mt-2'>${words.slice(0,count).join(' ')}...</p><button id='posterReveal' class='btn btn-sm btn-secondary mt-2'>Reveal More</button><div id='posterAnswer' class='mt-2'></div>`;
+      const img = document.getElementById('posterImg');
+      document.getElementById('posterReveal').addEventListener('click', () => {
+        if (blur > 0) {
+          blur -= 3;
+          if (blur < 0) blur = 0;
+          img.style.filter = `blur(${blur}px)`;
+        }
+        if (count < words.length) {
+          count += 3;
+          document.getElementById('posterSummary').innerText = words.slice(0,count).join(' ') + '...';
+        }
+        if (blur === 0 && count >= words.length) {
+          document.getElementById('posterReveal').disabled = true;
+          document.getElementById('posterAnswer').innerHTML = `Answer: ${data.title}`;
+        }
+      });
     } else {
       div.innerHTML = `<div class='alert alert-warning'>${data.error}</div>`;
     }

--- a/app/trivia.py
+++ b/app/trivia.py
@@ -7,11 +7,57 @@ class TriviaEngine:
     def __init__(self, plex_service):
         self.plex = plex_service
 
-    def random_question(self):
+    def _random_movie(self):
+        """Return a random movie from the Plex library."""
         movies = self.plex.get_movies()
         if not movies:
             return None
-        movie = random.choice(movies)
+        return random.choice(movies)
+
+    def random_question(self):
+        movie = self._random_movie()
+        if not movie:
+            return None
         question = f"Which movie features '{movie}'?"
         return {"question": question, "answer": movie}
+
+    def cast_reveal(self):
+        """Return the top few cast members for a random movie."""
+        movie = self._random_movie()
+        if not movie:
+            return None
+        try:
+            cast = [actor.tag for actor in movie.actors][:7]
+        except Exception:
+            cast = []
+
+        return {"title": movie.title, "cast": cast}
+
+    def guess_year(self):
+        """Return the title and year for a random movie."""
+        movie = self._random_movie()
+        if not movie:
+            return None
+        return {"title": movie.title, "year": movie.year, "summary": movie.summary}
+
+    def poster_reveal(self):
+        """Return poster and summary information for a random movie."""
+        movie = self._random_movie()
+        if not movie:
+            return None
+
+        poster = None
+        if hasattr(movie, "thumbUrl"):
+            poster = movie.thumbUrl
+        elif self.plex.server:
+            try:
+                poster = self.plex.server.url(movie.thumb)
+            except Exception:
+                poster = None
+
+        return {
+            "title": movie.title,
+            "poster": poster,
+            "summary": movie.summary,
+        }
 


### PR DESCRIPTION
## Summary
- redesign home page widgets to include Cast Reveal, Guess the Year and Poster Reveal games
- implement endpoints for new trivia games
- implement frontend logic for each game
- expand trivia engine with new game helpers
- document new game modes in README

## Testing
- `python -m py_compile app/*.py`

------
https://chatgpt.com/codex/tasks/task_e_68547ab8ba94833196c767477b04d613