### PR TITLE
Replace default widgets with trivia ideas

### DIFF
--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -1,31 +1,42 @@
 {% extends 'base.html' %}
 
 {% block content %}
-<h1 class="mb-4">Welcome to Plex Trivia</h1>
+<h1 class="mb-4">Movie &amp; TV Trivia Games</h1>
 <div class="row g-4">
   <div class="col-12 col-md-6 col-lg-4">
     <div class="card card-hover h-100">
       <div class="card-body">
-        <h5 class="card-title">Leaderboard</h5>
-        <p class="card-text">Top players will appear here.</p>
+        <h5 class="card-title">Cast Reveal Challenge</h5>
+        <p class="card-text">Guess the movie as more cast members are revealed each round.</p>
       </div>
     </div>
   </div>
+
   <div class="col-12 col-md-6 col-lg-4">
     <div class="card card-hover h-100">
       <div class="card-body">
-        <h5 class="card-title">Stats</h5>
-        <p class="card-text">Your trivia statistics will be displayed.</p>
-      </div>
-    </div>
-  </div>
-  <div class="col-12 col-md-6 col-lg-4">
-    <div class="card card-hover h-100">
-      <div class="card-body">
-        <h5 class="card-title">Random Trivia</h5>
-        <p class="card-text">Test your knowledge with a quick question.</p>
-        <button id="triviaBtn" class="btn btn-primary mt-2">Get Random Trivia</button>
+        <h5 class="card-title">Guess the Release Year</h5>
+        <p class="card-text">How well do you know movie release dates?</p>
+        <button id="triviaBtn" class="btn btn-primary mt-2">Get a Question</button>
         <div id="trivia" class="mt-3"></div>
+      </div>
+    </div>
+  </div>
+
+  <div class="col-12 col-md-6 col-lg-4">
+    <div class="card card-hover h-100">
+      <div class="card-body">
+        <h5 class="card-title">Poster Unblur</h5>
+        <p class="card-text">Identify the movie as the poster becomes clearer.</p>
+      </div>
+    </div>
+  </div>
+
+  <div class="col-12 col-md-6 col-lg-4">
+    <div class="card card-hover h-100">
+      <div class="card-body">
+        <h5 class="card-title">TV Tagline Quiz</h5>
+        <p class="card-text">Match memorable taglines to their shows.</p>
       </div>
     </div>
   </div>

--- a/app/trivia.py
+++ b/app/trivia.py
@@ -11,7 +11,19 @@ class TriviaEngine:
         movies = self.plex.get_movies()
         if not movies:
             return None
+
         movie = random.choice(movies)
-        question = f"Which movie features '{movie}'?"
-        return {"question": question, "answer": movie}
+        question_type = random.choice(["year", "summary"])
+
+        if question_type == "year":
+            question = f"In what year was '{movie.title}' released?"
+            answer = movie.year
+        else:
+            summary = getattr(movie, "summary", "").strip()
+            if not summary:
+                summary = "No summary available."
+            question = f"Which movie fits this description: '{summary}'"
+            answer = movie.title
+
+        return {"question": question, "answer": answer}
 


### PR DESCRIPTION
## Summary
- add example trivia widgets on the homepage
- support year and summary question types in the trivia engine

## Testing
- `python -m py_compile app/*.py`

------
https://chatgpt.com/codex/tasks/task_e_68547ab8ba94833196c767477b04d613