### PR TITLE
Add full-page trivia games with improved UI

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -13,6 +13,18 @@ def init_routes(app: Flask, plex_service: PlexService):
         shows = plex_service.get_shows()
         return render_template("index.html", movies=movies, shows=shows)
 
+    @bp.route("/games/cast")
+    def cast_game():
+        return render_template("cast.html")
+
+    @bp.route("/games/year")
+    def year_game():
+        return render_template("year.html")
+
+    @bp.route("/games/poster")
+    def poster_game():
+        return render_template("poster.html")
+
     @bp.route("/api/trivia")
     def api_trivia():
         q = trivia.random_question()
@@ -40,5 +52,11 @@ def init_routes(app: Flask, plex_service: PlexService):
         if not q:
             return jsonify({"error": "No media found"}), 404
         return jsonify(q)
+
+    @bp.route("/api/library")
+    def api_library():
+        movies = [m.title for m in plex_service.get_movies()]
+        shows = [s.title for s in plex_service.get_shows()]
+        return jsonify({"titles": movies + shows})
 
     app.register_blueprint(bp)

--- a/app/static/cast.js
+++ b/app/static/cast.js
@@ -1,0 +1,59 @@
+let castData = null;
+let index = 0;
+let titles = [];
+
+async function loadLibrary() {
+  const res = await fetch('/api/library');
+  const data = await res.json();
+  titles = data.titles || [];
+  const list = document.getElementById('titlesList');
+  list.innerHTML = titles.map(t => `<option value="${t}"></option>`).join('');
+}
+
+async function startGame() {
+  const res = await fetch('/api/trivia/cast');
+  castData = await res.json();
+  if (!castData.cast) {
+    document.getElementById('castResult').innerText = castData.error;
+    return;
+  }
+  renderCircles();
+}
+
+function renderCircles() {
+  const container = document.getElementById('castCircles');
+  container.innerHTML = '';
+  const total = 7;
+  for (let i = 0; i < total; i++) {
+    const div = document.createElement('div');
+    div.className = 'cast-circle d-flex align-items-center justify-content-center';
+    div.textContent = i <= index ? (castData.cast[i] || '?') : '?';
+    container.appendChild(div);
+  }
+  const pct = (index / (total - 1)) * 100;
+  document.getElementById('castProgress').style.width = pct + '%';
+}
+
+function handleGuess() {
+  const guess = document.getElementById('castGuess').value.trim().toLowerCase();
+  if (!guess) return;
+  if (guess === castData.title.toLowerCase()) {
+    document.getElementById('castResult').innerHTML = `<span class='text-success'>Correct! It was ${castData.title}.</span>`;
+    document.getElementById('castGuessBtn').disabled = true;
+  } else {
+    if (index < 6) {
+      index++;
+      renderCircles();
+      document.getElementById('castGuess').value = '';
+    } else {
+      document.getElementById('castResult').innerHTML = `Answer: ${castData.title}`;
+      document.getElementById('castGuessBtn').disabled = true;
+    }
+  }
+}
+
+document.getElementById('castGuessBtn').addEventListener('click', handleGuess);
+document.addEventListener('DOMContentLoaded', () => {
+  loadLibrary();
+  startGame();
+});

--- a/app/static/main.js
+++ b/app/static/main.js
@@ -1,0 +1,26 @@
+(function() {
+  const body = document.getElementById('body');
+  const sidebarToggle = document.getElementById('sidebarToggle');
+  const darkToggle = document.getElementById('darkModeToggle');
+
+  function applySettings() {
+    if (localStorage.getItem('darkMode') === 'true') {
+      body.classList.add('dark-mode');
+    }
+    if (localStorage.getItem('sidebarCollapsed') === 'true') {
+      body.classList.add('sidebar-collapsed');
+    }
+  }
+
+  sidebarToggle && sidebarToggle.addEventListener('click', () => {
+    body.classList.toggle('sidebar-collapsed');
+    localStorage.setItem('sidebarCollapsed', body.classList.contains('sidebar-collapsed'));
+  });
+
+  darkToggle && darkToggle.addEventListener('click', () => {
+    body.classList.toggle('dark-mode');
+    localStorage.setItem('darkMode', body.classList.contains('dark-mode'));
+  });
+
+  applySettings();
+})();

--- a/app/static/poster.js
+++ b/app/static/poster.js
@@ -1,0 +1,36 @@
+let posterData = null;
+let blur = 15;
+let count = 3;
+
+async function startPosterGame() {
+  const res = await fetch('/api/trivia/poster');
+  posterData = await res.json();
+  if (!posterData.poster) {
+    document.getElementById('posterResult').innerText = posterData.error;
+    return;
+  }
+  document.getElementById('posterImage').src = posterData.poster;
+  document.getElementById('posterSummary').innerText = posterData.summary.split(' ').slice(0, count).join(' ') + '...';
+}
+
+function revealMore() {
+  if (blur > 0) {
+    blur -= 3;
+    if (blur < 0) blur = 0;
+    document.getElementById('posterImage').style.filter = `blur(${blur}px)`;
+  }
+  const words = posterData.summary.split(' ');
+  if (count < words.length) {
+    count += 3;
+    document.getElementById('posterSummary').innerText = words.slice(0, count).join(' ') + '...';
+  }
+  const progress = ((15 - blur) / 15) * 100;
+  document.getElementById('posterProgress').style.width = progress + '%';
+  if (blur === 0 && count >= words.length) {
+    document.getElementById('posterReveal').disabled = true;
+    document.getElementById('posterResult').innerText = `Answer: ${posterData.title}`;
+  }
+}
+
+document.getElementById('posterReveal').addEventListener('click', revealMore);
+document.addEventListener('DOMContentLoaded', startPosterGame);

--- a/app/static/style.css
+++ b/app/static/style.css
@@ -26,3 +26,55 @@ body {
   transform: translateY(-3px);
   box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
 }
+
+/* Dark mode support */
+body.dark-mode {
+  background-color: #121212;
+  color: #f8f9fa;
+}
+
+body.dark-mode .navbar {
+  background-color: #343a40 !important;
+}
+
+body.dark-mode .sidebar {
+  background-color: #212529;
+  border-color: #343a40;
+}
+
+body.dark-mode .card {
+  background-color: #1e1e1e;
+  color: #f8f9fa;
+  border-color: #343a40;
+}
+
+/* Sidebar collapse */
+body.sidebar-collapsed .sidebar {
+  width: 60px !important;
+  overflow-x: hidden;
+}
+
+body.sidebar-collapsed .sidebar .nav-link,
+body.sidebar-collapsed .sidebar h6,
+body.sidebar-collapsed .sidebar img,
+body.sidebar-collapsed .sidebar h5 {
+  display: none;
+}
+
+/* Game layouts */
+.game-container {
+  max-width: 600px;
+  margin: 0 auto;
+}
+
+.cast-circle {
+  width: 80px;
+  height: 80px;
+  border-radius: 50%;
+  background-color: #e9ecef;
+}
+
+body.dark-mode .cast-circle {
+  background-color: #495057;
+  color: #f8f9fa;
+}

--- a/app/static/year.js
+++ b/app/static/year.js
@@ -1,0 +1,24 @@
+let yearData = null;
+
+async function startYearGame() {
+  const res = await fetch('/api/trivia/year');
+  yearData = await res.json();
+  if (!yearData.title) {
+    document.getElementById('yearResult').innerText = yearData.error;
+    return;
+  }
+  document.getElementById('yearQuestion').innerText = `What year did "${yearData.title}" release?`;
+}
+
+function guessYear() {
+  const value = parseInt(document.getElementById('yearInput').value, 10);
+  if (value === yearData.year) {
+    document.getElementById('yearResult').innerHTML = `<span class='text-success'>Correct!</span>`;
+  } else {
+    document.getElementById('yearResult').innerHTML = `Nope, it was ${yearData.year}`;
+  }
+  document.getElementById('yearSubmit').disabled = true;
+}
+
+document.getElementById('yearSubmit').addEventListener('click', guessYear);
+document.addEventListener('DOMContentLoaded', startYearGame);

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -7,15 +7,17 @@
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
     <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}">
   </head>
-  <body class="bg-light">
+  <body class="bg-light" id="body">
     <nav class="navbar navbar-dark bg-dark mb-4">
-      <div class="container-fluid">
-        <span class="navbar-brand mb-0 h1">Plex Trivia</span>
+      <div class="container-fluid d-flex align-items-center">
+        <button id="sidebarToggle" class="btn btn-outline-light btn-sm me-2" type="button">&#9776;</button>
+        <span class="navbar-brand mb-0 h1 flex-grow-1">Plex Trivia</span>
+        <button id="darkModeToggle" class="btn btn-outline-light btn-sm" type="button">Dark Mode</button>
       </div>
     </nav>
     <div class="container-fluid">
       <div class="row flex-nowrap">
-        <aside class="sidebar col-12 col-md-3 col-lg-2 p-3">
+        <aside id="sidebar" class="sidebar col-12 col-md-3 col-lg-2 p-3">
           <div class="text-center mb-4">
             <img src="https://via.placeholder.com/80" class="rounded-circle mb-2" alt="Profile picture">
             <h5 class="fw-bold">Guest</h5>
@@ -37,6 +39,7 @@
       </div>
     </div>
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
+    <script src="{{ url_for('static', filename='main.js') }}"></script>
   </body>
 </html>
 

--- a/app/templates/cast.html
+++ b/app/templates/cast.html
@@ -1,0 +1,17 @@
+{% extends 'base.html' %}
+{% block content %}
+<div class="game-container">
+  <h2 class="text-center mb-4">Cast Reveal</h2>
+  <div class="progress mb-3" style="height:5px;">
+    <div id="castProgress" class="progress-bar" role="progressbar" style="width:0%"></div>
+  </div>
+  <div id="castCircles" class="d-flex justify-content-center gap-3 mb-4"></div>
+  <div class="input-group mb-3">
+    <input id="castGuess" class="form-control" placeholder="Search and guess..." list="titlesList" autocomplete="off">
+    <button id="castGuessBtn" class="btn btn-primary" type="button">Guess</button>
+  </div>
+  <datalist id="titlesList"></datalist>
+  <div id="castResult" class="text-center fw-bold"></div>
+</div>
+<script src="{{ url_for('static', filename='cast.js') }}"></script>
+{% endblock %}

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -5,108 +5,30 @@
 <div class="row g-4">
   <div class="col-12 col-md-6 col-lg-4">
     <div class="card card-hover h-100">
-      <div class="card-body">
+      <div class="card-body d-flex flex-column">
         <h5 class="card-title">Cast Reveal Game</h5>
         <p class="card-text">Guess the movie as cast members are revealed.</p>
-        <button id="castBtn" class="btn btn-primary mt-2">Start</button>
-        <div id="castGame" class="mt-3"></div>
+        <a href="{{ url_for('main.cast_game') }}" class="btn btn-primary mt-auto">Start</a>
       </div>
     </div>
   </div>
   <div class="col-12 col-md-6 col-lg-4">
     <div class="card card-hover h-100">
-      <div class="card-body">
+      <div class="card-body d-flex flex-column">
         <h5 class="card-title">Guess the Year</h5>
         <p class="card-text">How well do you know release dates?</p>
-        <button id="yearBtn" class="btn btn-primary mt-2">New Question</button>
-        <div id="yearGame" class="mt-3"></div>
+        <a href="{{ url_for('main.year_game') }}" class="btn btn-primary mt-auto">Play</a>
       </div>
     </div>
   </div>
   <div class="col-12 col-md-6 col-lg-4">
     <div class="card card-hover h-100">
-      <div class="card-body">
+      <div class="card-body d-flex flex-column">
         <h5 class="card-title">Poster Reveal</h5>
         <p class="card-text">The image becomes clearer each round.</p>
-        <button id="posterBtn" class="btn btn-primary mt-2">Reveal Poster</button>
-        <div id="posterGame" class="mt-3 text-center"></div>
+        <a href="{{ url_for('main.poster_game') }}" class="btn btn-primary mt-auto">Start</a>
       </div>
     </div>
   </div>
 </div>
-
-<script>
-  document.getElementById('castBtn').addEventListener('click', async () => {
-    const res = await fetch('/api/trivia/cast');
-    const data = await res.json();
-    const div = document.getElementById('castGame');
-    if (data.cast) {
-      let index = 1;
-      div.innerHTML = `<div id='castList'></div><button id='revealCast' class='btn btn-sm btn-secondary mt-2'>Reveal Next</button>`;
-      const castList = document.getElementById('castList');
-      castList.innerHTML = `<span class='badge bg-info me-1'>${data.cast[0]}</span>`;
-      document.getElementById('revealCast').addEventListener('click', () => {
-        if (index < data.cast.length) {
-          castList.innerHTML += `<span class='badge bg-info me-1'>${data.cast[index]}</span>`;
-          index++;
-        } else {
-          document.getElementById('revealCast').disabled = true;
-          div.innerHTML += `<div class='mt-2 alert alert-primary'>Answer: ${data.title}</div>`;
-        }
-      });
-    } else {
-      div.innerHTML = `<div class='alert alert-warning'>${data.error}</div>`;
-    }
-  });
-
-  document.getElementById('yearBtn').addEventListener('click', async () => {
-    const res = await fetch('/api/trivia/year');
-    const data = await res.json();
-    const div = document.getElementById('yearGame');
-    if (data.title) {
-      div.innerHTML = `What year did <strong>${data.title}</strong> release? <input id='yearInput' class='form-control form-control-sm mt-2' placeholder='Enter year'><button id='yearGuess' class='btn btn-sm btn-secondary mt-2'>Guess</button><div id='yearAnswer' class='mt-2'></div>`;
-      document.getElementById('yearGuess').addEventListener('click', () => {
-        const guess = parseInt(document.getElementById('yearInput').value);
-        const ans = document.getElementById('yearAnswer');
-        if (guess === data.year) {
-          ans.innerHTML = `<span class='text-success'>Correct!</span>`;
-        } else {
-          ans.innerHTML = `<span class='text-danger'>Nope, it was ${data.year}</span>`;
-        }
-      });
-    } else {
-      div.innerHTML = `<div class='alert alert-warning'>${data.error}</div>`;
-    }
-  });
-
-  document.getElementById('posterBtn').addEventListener('click', async () => {
-    const res = await fetch('/api/trivia/poster');
-    const data = await res.json();
-    const div = document.getElementById('posterGame');
-    if (data.poster) {
-      let blur = 15;
-      const words = data.summary.split(' ');
-      let count = 3;
-      div.innerHTML = `<img id='posterImg' src='${data.poster}' style='max-width:100%;filter:blur(${blur}px);'><p id='posterSummary' class='mt-2'>${words.slice(0,count).join(' ')}...</p><button id='posterReveal' class='btn btn-sm btn-secondary mt-2'>Reveal More</button><div id='posterAnswer' class='mt-2'></div>`;
-      const img = document.getElementById('posterImg');
-      document.getElementById('posterReveal').addEventListener('click', () => {
-        if (blur > 0) {
-          blur -= 3;
-          if (blur < 0) blur = 0;
-          img.style.filter = `blur(${blur}px)`;
-        }
-        if (count < words.length) {
-          count += 3;
-          document.getElementById('posterSummary').innerText = words.slice(0,count).join(' ') + '...';
-        }
-        if (blur === 0 && count >= words.length) {
-          document.getElementById('posterReveal').disabled = true;
-          document.getElementById('posterAnswer').innerHTML = `Answer: ${data.title}`;
-        }
-      });
-    } else {
-      div.innerHTML = `<div class='alert alert-warning'>${data.error}</div>`;
-    }
-  });
-</script>
 {% endblock %}

--- a/app/templates/poster.html
+++ b/app/templates/poster.html
@@ -1,0 +1,14 @@
+{% extends 'base.html' %}
+{% block content %}
+<div class="game-container text-center">
+  <h2 class="mb-4">Poster Reveal</h2>
+  <div class="progress mb-3" style="height:5px;">
+    <div id="posterProgress" class="progress-bar" role="progressbar" style="width:0%"></div>
+  </div>
+  <img id="posterImage" class="mb-3" style="max-width:100%;filter:blur(15px);">
+  <p id="posterSummary" class="mb-3"></p>
+  <button id="posterReveal" class="btn btn-primary mb-3" type="button">Reveal More</button>
+  <div id="posterResult" class="fw-bold"></div>
+</div>
+<script src="{{ url_for('static', filename='poster.js') }}"></script>
+{% endblock %}

--- a/app/templates/year.html
+++ b/app/templates/year.html
@@ -1,0 +1,13 @@
+{% extends 'base.html' %}
+{% block content %}
+<div class="game-container text-center">
+  <h2 class="mb-4">Guess the Year</h2>
+  <div id="yearQuestion" class="h4 mb-3"></div>
+  <div class="input-group mb-3 justify-content-center">
+    <input id="yearInput" class="form-control w-auto" placeholder="Enter year" autocomplete="off">
+    <button id="yearSubmit" class="btn btn-primary" type="button">Submit</button>
+  </div>
+  <div id="yearResult" class="fw-bold"></div>
+</div>
+<script src="{{ url_for('static', filename='year.js') }}"></script>
+{% endblock %}


### PR DESCRIPTION
## Summary
- create standalone pages for Cast Reveal, Guess the Year and Poster Reveal games
- allow navigation via new routes
- add sidebar collapse and dark mode toggle
- tweak styles for dark mode and games
- refactor index page to link to game pages
- include client scripts for each game

## Testing
- `python -m py_compile app/*.py`

------
https://chatgpt.com/codex/tasks/task_e_68547e2989b48331b59b3bae3494eea7