### PR TITLE
Enhance trivia UI with dedicated game pages

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -9,9 +9,25 @@ def init_routes(app: Flask, plex_service: PlexService):
 
     @bp.route("/")
     def index():
-        movies = plex_service.get_movies()
-        shows = plex_service.get_shows()
-        return render_template("index.html", movies=movies, shows=shows)
+        """Homepage with game selection."""
+        return render_template("index.html")
+
+    # ----- Game Pages -----
+
+    @bp.route("/game/cast")
+    def game_cast():
+        """Full page Cast Reveal game."""
+        return render_template("cast_game.html")
+
+    @bp.route("/game/year")
+    def game_year():
+        """Full page Guess the Year game."""
+        return render_template("year_game.html")
+
+    @bp.route("/game/poster")
+    def game_poster():
+        """Full page Poster Reveal game."""
+        return render_template("poster_game.html")
 
     @bp.route("/api/trivia")
     def api_trivia():
@@ -40,5 +56,12 @@ def init_routes(app: Flask, plex_service: PlexService):
         if not q:
             return jsonify({"error": "No media found"}), 404
         return jsonify(q)
+
+    @bp.route("/api/titles")
+    def api_titles():
+        """Return a combined list of movie and show titles."""
+        movie_titles = [m.title for m in plex_service.get_movies()]
+        show_titles = [s.title for s in plex_service.get_shows()]
+        return jsonify({"titles": movie_titles + show_titles})
 
     app.register_blueprint(bp)

--- a/app/static/cast_game.js
+++ b/app/static/cast_game.js
@@ -1,0 +1,51 @@
+(async function() {
+  const res = await fetch('/api/trivia/cast');
+  const data = await res.json();
+  const titlesRes = await fetch('/api/titles');
+  const titleData = await titlesRes.json();
+  const dataList = document.getElementById('titles');
+  titleData.titles.forEach(t => {
+    const opt = document.createElement('option');
+    opt.value = t;
+    dataList.appendChild(opt);
+  });
+
+  let cast = data.cast || [];
+  const title = data.title || '';
+  let round = 0;
+
+  function updateProgress() {
+    const width = ((round + 1) / cast.length) * 100;
+    document.getElementById('roundProgress').style.width = width + '%';
+  }
+
+  if (cast.length) {
+    document.getElementById('cast0').innerText = cast[0];
+    updateProgress();
+  }
+
+  document.getElementById('guessBtn').addEventListener('click', () => {
+    const guessInput = document.getElementById('guessInput');
+    const guess = guessInput.value.trim().toLowerCase();
+    if (!guess) return;
+    if (guess === title.toLowerCase()) {
+      document.getElementById('gameMessage').innerHTML = `<span class='text-success'>Correct! ${title}</span>`;
+      cast.forEach((c, i) => {
+        document.getElementById('cast' + i).innerText = c;
+      });
+      document.getElementById('guessBtn').disabled = true;
+      document.getElementById('roundProgress').style.width = '100%';
+      return;
+    }
+    round++;
+    guessInput.value = '';
+    if (round < cast.length) {
+      document.getElementById('cast' + round).innerText = cast[round];
+      updateProgress();
+    } else {
+      document.getElementById('gameMessage').innerHTML = `Out of clues! The answer was <strong>${title}</strong>`;
+      document.getElementById('guessBtn').disabled = true;
+      updateProgress();
+    }
+  });
+})();

--- a/app/static/poster_game.js
+++ b/app/static/poster_game.js
@@ -1,0 +1,31 @@
+(async function() {
+  const res = await fetch('/api/trivia/poster');
+  const data = await res.json();
+  if (!data.poster) {
+    document.getElementById('posterAnswer').innerText = data.error || 'No media found';
+    document.getElementById('posterReveal').disabled = true;
+    return;
+  }
+  document.getElementById('posterImg').src = data.poster;
+  const words = data.summary.split(' ');
+  let blur = 15;
+  let count = 3;
+  document.getElementById('posterSummary').innerText = words.slice(0, count).join(' ') + '...';
+  let title = data.title;
+
+  document.getElementById('posterReveal').addEventListener('click', () => {
+    if (blur > 0) {
+      blur -= 3;
+      if (blur < 0) blur = 0;
+      document.getElementById('posterImg').style.filter = `blur(${blur}px)`;
+    }
+    if (count < words.length) {
+      count += 3;
+      document.getElementById('posterSummary').innerText = words.slice(0, count).join(' ') + '...';
+    }
+    if (blur === 0 && count >= words.length) {
+      document.getElementById('posterReveal').disabled = true;
+      document.getElementById('posterAnswer').innerText = `Answer: ${title}`;
+    }
+  });
+})();

--- a/app/static/style.css
+++ b/app/static/style.css
@@ -2,6 +2,16 @@ body {
   font-family: "Segoe UI", Tahoma, Geneva, Verdana, sans-serif;
 }
 
+body.dark-mode {
+  background-color: #121212;
+  color: #f8f9fa;
+}
+
+.dark-mode .card {
+  background-color: #1e1e1e;
+  color: #f8f9fa;
+}
+
 .sidebar {
   background-color: #f8f9fa;
   min-height: 100vh;
@@ -25,4 +35,25 @@ body {
 .card-hover:hover {
   transform: translateY(-3px);
   box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
+}
+
+.cast-circle {
+  width: 100px;
+  height: 100px;
+  border-radius: 50%;
+  background-color: #e9ecef;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: 600;
+}
+
+body.dark-mode .cast-circle {
+  background-color: #333;
+  color: #fff;
+}
+
+.game-container {
+  max-width: 800px;
+  margin: 0 auto;
 }

--- a/app/static/year_game.js
+++ b/app/static/year_game.js
@@ -1,0 +1,20 @@
+(async function() {
+  const res = await fetch('/api/trivia/year');
+  const data = await res.json();
+  if (!data.title) {
+    document.getElementById('question').innerText = data.error || 'No media found';
+    document.getElementById('yearGuess').disabled = true;
+    return;
+  }
+  document.getElementById('question').innerText = `What year was "${data.title}" released?`;
+  const answer = data.year;
+
+  document.getElementById('yearGuess').addEventListener('click', () => {
+    const guess = parseInt(document.getElementById('yearInput').value, 10);
+    if (guess === answer) {
+      document.getElementById('yearResult').innerHTML = `<span class='text-success'>Correct!</span>`;
+    } else {
+      document.getElementById('yearResult').innerHTML = `Nope, it was ${answer}`;
+    }
+  });
+})();

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -7,10 +7,15 @@
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
     <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}">
   </head>
-  <body class="bg-light">
+  <body>
     <nav class="navbar navbar-dark bg-dark mb-4">
       <div class="container-fluid">
+        <button class="btn btn-outline-light me-2" id="sidebarToggle">&#9776;</button>
         <span class="navbar-brand mb-0 h1">Plex Trivia</span>
+        <div class="form-check form-switch text-light ms-auto">
+          <input class="form-check-input" type="checkbox" id="darkModeToggle">
+          <label class="form-check-label" for="darkModeToggle">Dark</label>
+        </div>
       </div>
     </nav>
     <div class="container-fluid">
@@ -37,6 +42,14 @@
       </div>
     </div>
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
+    <script>
+      document.getElementById('sidebarToggle').addEventListener('click', () => {
+        document.querySelector('.sidebar').classList.toggle('d-none');
+      });
+      document.getElementById('darkModeToggle').addEventListener('change', (e) => {
+        document.body.classList.toggle('dark-mode', e.target.checked);
+      });
+    </script>
   </body>
 </html>
 

--- a/app/templates/cast_game.html
+++ b/app/templates/cast_game.html
@@ -1,0 +1,21 @@
+{% extends 'base.html' %}
+
+{% block content %}
+<div class="game-container text-center">
+  <div class="progress mb-4" style="height: 8px;">
+    <div id="roundProgress" class="progress-bar" role="progressbar" style="width:0%"></div>
+  </div>
+  <div id="castIcons" class="d-flex justify-content-center gap-3 mb-4">
+    {% for i in range(7) %}
+    <div class="cast-circle" id="cast{{ i }}">?</div>
+    {% endfor %}
+  </div>
+  <div class="d-flex justify-content-center mb-3">
+    <input list="titles" id="guessInput" class="form-control w-auto me-2" placeholder="Your guess">
+    <datalist id="titles"></datalist>
+    <button id="guessBtn" class="btn btn-primary">Guess</button>
+  </div>
+  <div id="gameMessage" class="mt-3"></div>
+</div>
+<script src="{{ url_for('static', filename='cast_game.js') }}"></script>
+{% endblock %}

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -5,108 +5,30 @@
 <div class="row g-4">
   <div class="col-12 col-md-6 col-lg-4">
     <div class="card card-hover h-100">
-      <div class="card-body">
+      <div class="card-body text-center">
         <h5 class="card-title">Cast Reveal Game</h5>
         <p class="card-text">Guess the movie as cast members are revealed.</p>
-        <button id="castBtn" class="btn btn-primary mt-2">Start</button>
-        <div id="castGame" class="mt-3"></div>
+        <a href="{{ url_for('game_cast') }}" class="btn btn-primary mt-2">Start</a>
       </div>
     </div>
   </div>
   <div class="col-12 col-md-6 col-lg-4">
     <div class="card card-hover h-100">
-      <div class="card-body">
+      <div class="card-body text-center">
         <h5 class="card-title">Guess the Year</h5>
         <p class="card-text">How well do you know release dates?</p>
-        <button id="yearBtn" class="btn btn-primary mt-2">New Question</button>
-        <div id="yearGame" class="mt-3"></div>
+        <a href="{{ url_for('game_year') }}" class="btn btn-primary mt-2">Start</a>
       </div>
     </div>
   </div>
   <div class="col-12 col-md-6 col-lg-4">
     <div class="card card-hover h-100">
-      <div class="card-body">
+      <div class="card-body text-center">
         <h5 class="card-title">Poster Reveal</h5>
         <p class="card-text">The image becomes clearer each round.</p>
-        <button id="posterBtn" class="btn btn-primary mt-2">Reveal Poster</button>
-        <div id="posterGame" class="mt-3 text-center"></div>
+        <a href="{{ url_for('game_poster') }}" class="btn btn-primary mt-2">Start</a>
       </div>
     </div>
   </div>
 </div>
-
-<script>
-  document.getElementById('castBtn').addEventListener('click', async () => {
-    const res = await fetch('/api/trivia/cast');
-    const data = await res.json();
-    const div = document.getElementById('castGame');
-    if (data.cast) {
-      let index = 1;
-      div.innerHTML = `<div id='castList'></div><button id='revealCast' class='btn btn-sm btn-secondary mt-2'>Reveal Next</button>`;
-      const castList = document.getElementById('castList');
-      castList.innerHTML = `<span class='badge bg-info me-1'>${data.cast[0]}</span>`;
-      document.getElementById('revealCast').addEventListener('click', () => {
-        if (index < data.cast.length) {
-          castList.innerHTML += `<span class='badge bg-info me-1'>${data.cast[index]}</span>`;
-          index++;
-        } else {
-          document.getElementById('revealCast').disabled = true;
-          div.innerHTML += `<div class='mt-2 alert alert-primary'>Answer: ${data.title}</div>`;
-        }
-      });
-    } else {
-      div.innerHTML = `<div class='alert alert-warning'>${data.error}</div>`;
-    }
-  });
-
-  document.getElementById('yearBtn').addEventListener('click', async () => {
-    const res = await fetch('/api/trivia/year');
-    const data = await res.json();
-    const div = document.getElementById('yearGame');
-    if (data.title) {
-      div.innerHTML = `What year did <strong>${data.title}</strong> release? <input id='yearInput' class='form-control form-control-sm mt-2' placeholder='Enter year'><button id='yearGuess' class='btn btn-sm btn-secondary mt-2'>Guess</button><div id='yearAnswer' class='mt-2'></div>`;
-      document.getElementById('yearGuess').addEventListener('click', () => {
-        const guess = parseInt(document.getElementById('yearInput').value);
-        const ans = document.getElementById('yearAnswer');
-        if (guess === data.year) {
-          ans.innerHTML = `<span class='text-success'>Correct!</span>`;
-        } else {
-          ans.innerHTML = `<span class='text-danger'>Nope, it was ${data.year}</span>`;
-        }
-      });
-    } else {
-      div.innerHTML = `<div class='alert alert-warning'>${data.error}</div>`;
-    }
-  });
-
-  document.getElementById('posterBtn').addEventListener('click', async () => {
-    const res = await fetch('/api/trivia/poster');
-    const data = await res.json();
-    const div = document.getElementById('posterGame');
-    if (data.poster) {
-      let blur = 15;
-      const words = data.summary.split(' ');
-      let count = 3;
-      div.innerHTML = `<img id='posterImg' src='${data.poster}' style='max-width:100%;filter:blur(${blur}px);'><p id='posterSummary' class='mt-2'>${words.slice(0,count).join(' ')}...</p><button id='posterReveal' class='btn btn-sm btn-secondary mt-2'>Reveal More</button><div id='posterAnswer' class='mt-2'></div>`;
-      const img = document.getElementById('posterImg');
-      document.getElementById('posterReveal').addEventListener('click', () => {
-        if (blur > 0) {
-          blur -= 3;
-          if (blur < 0) blur = 0;
-          img.style.filter = `blur(${blur}px)`;
-        }
-        if (count < words.length) {
-          count += 3;
-          document.getElementById('posterSummary').innerText = words.slice(0,count).join(' ') + '...';
-        }
-        if (blur === 0 && count >= words.length) {
-          document.getElementById('posterReveal').disabled = true;
-          document.getElementById('posterAnswer').innerHTML = `Answer: ${data.title}`;
-        }
-      });
-    } else {
-      div.innerHTML = `<div class='alert alert-warning'>${data.error}</div>`;
-    }
-  });
-</script>
 {% endblock %}

--- a/app/templates/poster_game.html
+++ b/app/templates/poster_game.html
@@ -1,0 +1,11 @@
+{% extends 'base.html' %}
+
+{% block content %}
+<div class="game-container text-center">
+  <img id="posterImg" class="mb-3" style="max-width:100%;filter:blur(15px);">
+  <p id="posterSummary" class="mb-3"></p>
+  <button id="posterReveal" class="btn btn-primary">Reveal More</button>
+  <div id="posterAnswer" class="mt-3"></div>
+</div>
+<script src="{{ url_for('static', filename='poster_game.js') }}"></script>
+{% endblock %}

--- a/app/templates/year_game.html
+++ b/app/templates/year_game.html
@@ -1,0 +1,13 @@
+{% extends 'base.html' %}
+
+{% block content %}
+<div class="game-container text-center">
+  <h2 id="question" class="mb-4"></h2>
+  <div class="d-flex justify-content-center mb-3">
+    <input id="yearInput" type="number" class="form-control w-auto me-2" placeholder="Enter year">
+    <button id="yearGuess" class="btn btn-primary">Guess</button>
+  </div>
+  <div id="yearResult" class="mt-3"></div>
+</div>
+<script src="{{ url_for('static', filename='year_game.js') }}"></script>
+{% endblock %}


### PR DESCRIPTION
## Summary
- add routes for dedicated Cast, Year, and Poster games
- create new templates and JS for each game
- redesign homepage to link to game pages
- implement sidebar collapse and dark‑mode toggle
- update styles for games and dark mode

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68547e2989b48331b59b3bae3494eea7