### PR TITLE
Implement separate trivia game pages

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -13,6 +13,18 @@ def init_routes(app: Flask, plex_service: PlexService):
         shows = plex_service.get_shows()
         return render_template("index.html", movies=movies, shows=shows)
 
+    @bp.route("/game/cast")
+    def cast_game_page():
+        return render_template("game_cast.html")
+
+    @bp.route("/game/year")
+    def year_game_page():
+        return render_template("game_year.html")
+
+    @bp.route("/game/poster")
+    def poster_game_page():
+        return render_template("game_poster.html")
+
     @bp.route("/api/trivia")
     def api_trivia():
         q = trivia.random_question()
@@ -40,5 +52,11 @@ def init_routes(app: Flask, plex_service: PlexService):
         if not q:
             return jsonify({"error": "No media found"}), 404
         return jsonify(q)
+
+    @bp.route("/api/library")
+    def api_library():
+        movies = [m.title for m in plex_service.get_movies()]
+        shows = [s.title for s in plex_service.get_shows()]
+        return jsonify({"movies": movies, "shows": shows})
 
     app.register_blueprint(bp)

--- a/app/static/base.js
+++ b/app/static/base.js
@@ -1,0 +1,27 @@
+// Controls sidebar collapse and dark mode toggle
+function initLayoutControls() {
+  const sidebar = document.querySelector('.sidebar');
+  const toggleSidebar = document.getElementById('toggleSidebar');
+  const toggleDark = document.getElementById('toggleDark');
+  const body = document.body;
+
+  toggleSidebar.addEventListener('click', () => {
+    sidebar.classList.toggle('collapsed');
+  });
+
+  function setDark(enabled) {
+    body.classList.toggle('dark-mode', enabled);
+    localStorage.setItem('darkMode', enabled ? '1' : '0');
+  }
+
+  toggleDark.addEventListener('click', () => {
+    setDark(!body.classList.contains('dark-mode'));
+  });
+
+  // load saved mode
+  if (localStorage.getItem('darkMode') === '1') {
+    body.classList.add('dark-mode');
+  }
+}
+
+document.addEventListener('DOMContentLoaded', initLayoutControls);

--- a/app/static/cast.js
+++ b/app/static/cast.js
@@ -1,0 +1,62 @@
+// Cast Reveal Game logic
+
+document.addEventListener('DOMContentLoaded', () => {
+  const icons = document.getElementById('castIcons');
+  const progress = document.getElementById('roundProgress');
+  const guessBtn = document.getElementById('guessBtn');
+  const guessInput = document.getElementById('guessInput');
+  const result = document.getElementById('result');
+  const titleList = document.getElementById('titleList');
+  let data = null;
+  let round = 1;
+
+  function updateProgress() {
+    progress.style.width = (round / 7 * 100) + '%';
+    progress.setAttribute('aria-valuenow', round);
+  }
+
+  async function loadTitles() {
+    const res = await fetch('/api/library');
+    const library = await res.json();
+    [...library.movies, ...library.shows].forEach(t => {
+      const opt = document.createElement('option');
+      opt.value = t;
+      titleList.appendChild(opt);
+    });
+  }
+
+  async function initGame() {
+    const res = await fetch('/api/trivia/cast');
+    data = await res.json();
+    icons.innerHTML = '';
+    for (let i = 0; i < 7; i++) {
+      const d = document.createElement('div');
+      d.className = 'cast-circle';
+      d.textContent = i === 0 && data.cast.length > 0 ? data.cast[0] : '?';
+      icons.appendChild(d);
+    }
+    updateProgress();
+  }
+
+  guessBtn.addEventListener('click', () => {
+    const guess = guessInput.value.trim().toLowerCase();
+    if (!data) return;
+    if (guess === data.title.toLowerCase()) {
+      result.innerHTML = `<div class='alert alert-success'>Correct! It was ${data.title}</div>`;
+      guessBtn.disabled = true;
+    } else {
+      round++;
+      if (round <= data.cast.length) {
+        document.querySelectorAll('.cast-circle')[round-1].textContent = data.cast[round-1];
+        result.innerHTML = `<div class='alert alert-danger'>Try again!</div>`;
+      } else {
+        result.innerHTML = `<div class='alert alert-info'>Out of guesses. It was ${data.title}</div>`;
+        guessBtn.disabled = true;
+      }
+      updateProgress();
+    }
+  });
+
+  loadTitles();
+  initGame();
+});

--- a/app/static/poster.js
+++ b/app/static/poster.js
@@ -1,0 +1,39 @@
+// Poster Reveal game logic
+
+document.addEventListener('DOMContentLoaded', () => {
+  const img = document.getElementById('posterImg');
+  const summary = document.getElementById('posterSummary');
+  const revealBtn = document.getElementById('posterReveal');
+  const result = document.getElementById('posterAnswer');
+  let data = null;
+  let blur = 15;
+  let count = 3;
+
+  async function init() {
+    const res = await fetch('/api/trivia/poster');
+    data = await res.json();
+    if (data.poster) {
+      img.src = data.poster;
+    }
+    summary.textContent = data.summary.split(' ').slice(0, count).join(' ') + '...';
+  }
+
+  revealBtn.addEventListener('click', () => {
+    if (blur > 0) {
+      blur -= 3;
+      if (blur < 0) blur = 0;
+      img.style.filter = `blur(${blur}px)`;
+    }
+    const words = data.summary.split(' ');
+    if (count < words.length) {
+      count += 3;
+      summary.textContent = words.slice(0, count).join(' ') + '...';
+    }
+    if (blur === 0 && count >= words.length) {
+      revealBtn.disabled = true;
+      result.textContent = `Answer: ${data.title}`;
+    }
+  });
+
+  init();
+});

--- a/app/static/style.css
+++ b/app/static/style.css
@@ -2,10 +2,40 @@ body {
   font-family: "Segoe UI", Tahoma, Geneva, Verdana, sans-serif;
 }
 
+body.dark-mode {
+  background-color: #121212;
+  color: #e0e0e0;
+}
+
+body.dark-mode .navbar {
+  background-color: #1f1f1f;
+}
+
+body.dark-mode .sidebar {
+  background-color: #1f1f1f;
+  border-color: #333;
+}
+
+body.dark-mode .card {
+  background-color: #242424;
+  color: #e0e0e0;
+}
+
 .sidebar {
   background-color: #f8f9fa;
   min-height: 100vh;
   border-right: 1px solid #dee2e6;
+  transition: width 0.3s ease;
+}
+
+.sidebar.collapsed {
+  width: 60px !important;
+}
+
+.sidebar.collapsed .nav-link,
+.sidebar.collapsed h6,
+.sidebar.collapsed .text-center {
+  display: none;
 }
 
 .sidebar .nav-link {
@@ -25,4 +55,28 @@ body {
 .card-hover:hover {
   transform: translateY(-3px);
   box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
+}
+
+.cast-icons {
+  display: flex;
+  justify-content: center;
+  flex-wrap: wrap;
+  gap: 1rem;
+  margin-bottom: 1rem;
+}
+
+.cast-circle {
+  width: 100px;
+  height: 100px;
+  border-radius: 50%;
+  background-color: #e9ecef;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: 600;
+}
+
+body.dark-mode .cast-circle {
+  background-color: #343a40;
+  color: #e0e0e0;
 }

--- a/app/static/year.js
+++ b/app/static/year.js
@@ -1,0 +1,28 @@
+// Guess the Year game logic
+
+document.addEventListener('DOMContentLoaded', () => {
+  const question = document.getElementById('yearQuestion');
+  const guessInput = document.getElementById('yearInput');
+  const guessBtn = document.getElementById('yearGuess');
+  const result = document.getElementById('yearResult');
+  let data = null;
+
+  async function newQuestion() {
+    const res = await fetch('/api/trivia/year');
+    data = await res.json();
+    question.textContent = `What year did ${data.title} release?`;
+    guessInput.value = '';
+    result.textContent = '';
+  }
+
+  guessBtn.addEventListener('click', () => {
+    const guess = parseInt(guessInput.value, 10);
+    if (guess === data.year) {
+      result.innerHTML = `<span class='text-success'>Correct!</span>`;
+    } else {
+      result.innerHTML = `<span class='text-danger'>Nope, it was ${data.year}</span>`;
+    }
+  });
+
+  newQuestion();
+});

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -9,8 +9,12 @@
   </head>
   <body class="bg-light">
     <nav class="navbar navbar-dark bg-dark mb-4">
-      <div class="container-fluid">
+      <div class="container-fluid d-flex align-items-center">
+        <button id="toggleSidebar" class="btn btn-outline-light me-2">&#9776;</button>
         <span class="navbar-brand mb-0 h1">Plex Trivia</span>
+        <div class="ms-auto">
+          <button id="toggleDark" class="btn btn-outline-light">Dark Mode</button>
+        </div>
       </div>
     </nav>
     <div class="container-fluid">
@@ -37,6 +41,7 @@
       </div>
     </div>
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
+    <script src="{{ url_for('static', filename='base.js') }}"></script>
   </body>
 </html>
 

--- a/app/templates/game_cast.html
+++ b/app/templates/game_cast.html
@@ -1,0 +1,18 @@
+{% extends 'base.html' %}
+
+{% block content %}
+<div class="game-container text-center">
+  <h2 class="mb-4">Cast Reveal</h2>
+  <div class="progress mb-4" style="height:8px;">
+    <div id="roundProgress" class="progress-bar" role="progressbar" aria-valuenow="1" aria-valuemin="0" aria-valuemax="7" style="width:14%"></div>
+  </div>
+  <div id="castIcons" class="cast-icons"></div>
+  <div class="input-group mb-3">
+    <input id="guessInput" list="titleList" class="form-control" placeholder="Search titles">
+    <datalist id="titleList"></datalist>
+    <button class="btn btn-primary" id="guessBtn">Guess</button>
+  </div>
+  <div id="result" class="mt-3"></div>
+</div>
+<script src="{{ url_for('static', filename='cast.js') }}"></script>
+{% endblock %}

--- a/app/templates/game_poster.html
+++ b/app/templates/game_poster.html
@@ -1,0 +1,12 @@
+{% extends 'base.html' %}
+
+{% block content %}
+<div class="game-container text-center">
+  <h2 class="mb-4">Poster Reveal</h2>
+  <img id="posterImg" style="max-width:100%;filter:blur(15px);" class="mb-3" />
+  <p id="posterSummary" class="mb-3"></p>
+  <button id="posterReveal" class="btn btn-primary">Reveal More</button>
+  <div id="posterAnswer" class="mt-3"></div>
+</div>
+<script src="{{ url_for('static', filename='poster.js') }}"></script>
+{% endblock %}

--- a/app/templates/game_year.html
+++ b/app/templates/game_year.html
@@ -1,0 +1,13 @@
+{% extends 'base.html' %}
+
+{% block content %}
+<div class="game-container text-center">
+  <h2 class="mb-4" id="yearQuestion"></h2>
+  <div class="input-group mb-3 w-50 mx-auto">
+    <input id="yearInput" class="form-control" placeholder="Enter year">
+    <button class="btn btn-primary" id="yearGuess">Guess</button>
+  </div>
+  <div id="yearResult" class="mt-3"></div>
+</div>
+<script src="{{ url_for('static', filename='year.js') }}"></script>
+{% endblock %}

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -5,108 +5,30 @@
 <div class="row g-4">
   <div class="col-12 col-md-6 col-lg-4">
     <div class="card card-hover h-100">
-      <div class="card-body">
+      <div class="card-body text-center">
         <h5 class="card-title">Cast Reveal Game</h5>
         <p class="card-text">Guess the movie as cast members are revealed.</p>
-        <button id="castBtn" class="btn btn-primary mt-2">Start</button>
-        <div id="castGame" class="mt-3"></div>
+        <a href="{{ url_for('main.cast_game_page') }}" class="btn btn-primary mt-2">Play</a>
       </div>
     </div>
   </div>
   <div class="col-12 col-md-6 col-lg-4">
     <div class="card card-hover h-100">
-      <div class="card-body">
+      <div class="card-body text-center">
         <h5 class="card-title">Guess the Year</h5>
         <p class="card-text">How well do you know release dates?</p>
-        <button id="yearBtn" class="btn btn-primary mt-2">New Question</button>
-        <div id="yearGame" class="mt-3"></div>
+        <a href="{{ url_for('main.year_game_page') }}" class="btn btn-primary mt-2">Play</a>
       </div>
     </div>
   </div>
   <div class="col-12 col-md-6 col-lg-4">
     <div class="card card-hover h-100">
-      <div class="card-body">
+      <div class="card-body text-center">
         <h5 class="card-title">Poster Reveal</h5>
         <p class="card-text">The image becomes clearer each round.</p>
-        <button id="posterBtn" class="btn btn-primary mt-2">Reveal Poster</button>
-        <div id="posterGame" class="mt-3 text-center"></div>
+        <a href="{{ url_for('main.poster_game_page') }}" class="btn btn-primary mt-2">Play</a>
       </div>
     </div>
   </div>
 </div>
-
-<script>
-  document.getElementById('castBtn').addEventListener('click', async () => {
-    const res = await fetch('/api/trivia/cast');
-    const data = await res.json();
-    const div = document.getElementById('castGame');
-    if (data.cast) {
-      let index = 1;
-      div.innerHTML = `<div id='castList'></div><button id='revealCast' class='btn btn-sm btn-secondary mt-2'>Reveal Next</button>`;
-      const castList = document.getElementById('castList');
-      castList.innerHTML = `<span class='badge bg-info me-1'>${data.cast[0]}</span>`;
-      document.getElementById('revealCast').addEventListener('click', () => {
-        if (index < data.cast.length) {
-          castList.innerHTML += `<span class='badge bg-info me-1'>${data.cast[index]}</span>`;
-          index++;
-        } else {
-          document.getElementById('revealCast').disabled = true;
-          div.innerHTML += `<div class='mt-2 alert alert-primary'>Answer: ${data.title}</div>`;
-        }
-      });
-    } else {
-      div.innerHTML = `<div class='alert alert-warning'>${data.error}</div>`;
-    }
-  });
-
-  document.getElementById('yearBtn').addEventListener('click', async () => {
-    const res = await fetch('/api/trivia/year');
-    const data = await res.json();
-    const div = document.getElementById('yearGame');
-    if (data.title) {
-      div.innerHTML = `What year did <strong>${data.title}</strong> release? <input id='yearInput' class='form-control form-control-sm mt-2' placeholder='Enter year'><button id='yearGuess' class='btn btn-sm btn-secondary mt-2'>Guess</button><div id='yearAnswer' class='mt-2'></div>`;
-      document.getElementById('yearGuess').addEventListener('click', () => {
-        const guess = parseInt(document.getElementById('yearInput').value);
-        const ans = document.getElementById('yearAnswer');
-        if (guess === data.year) {
-          ans.innerHTML = `<span class='text-success'>Correct!</span>`;
-        } else {
-          ans.innerHTML = `<span class='text-danger'>Nope, it was ${data.year}</span>`;
-        }
-      });
-    } else {
-      div.innerHTML = `<div class='alert alert-warning'>${data.error}</div>`;
-    }
-  });
-
-  document.getElementById('posterBtn').addEventListener('click', async () => {
-    const res = await fetch('/api/trivia/poster');
-    const data = await res.json();
-    const div = document.getElementById('posterGame');
-    if (data.poster) {
-      let blur = 15;
-      const words = data.summary.split(' ');
-      let count = 3;
-      div.innerHTML = `<img id='posterImg' src='${data.poster}' style='max-width:100%;filter:blur(${blur}px);'><p id='posterSummary' class='mt-2'>${words.slice(0,count).join(' ')}...</p><button id='posterReveal' class='btn btn-sm btn-secondary mt-2'>Reveal More</button><div id='posterAnswer' class='mt-2'></div>`;
-      const img = document.getElementById('posterImg');
-      document.getElementById('posterReveal').addEventListener('click', () => {
-        if (blur > 0) {
-          blur -= 3;
-          if (blur < 0) blur = 0;
-          img.style.filter = `blur(${blur}px)`;
-        }
-        if (count < words.length) {
-          count += 3;
-          document.getElementById('posterSummary').innerText = words.slice(0,count).join(' ') + '...';
-        }
-        if (blur === 0 && count >= words.length) {
-          document.getElementById('posterReveal').disabled = true;
-          document.getElementById('posterAnswer').innerHTML = `Answer: ${data.title}`;
-        }
-      });
-    } else {
-      div.innerHTML = `<div class='alert alert-warning'>${data.error}</div>`;
-    }
-  });
-</script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- add collapsible sidebar and dark mode toggle
- create new pages for Cast Reveal, Guess the Year and Poster Reveal
- move game logic to separate JS files
- style games with a simple modern UI
- expose library titles via new API route

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68547e2989b48331b59b3bae3494eea7