### PR TITLE
Refactor trivia games into separate pages

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -13,6 +13,18 @@ def init_routes(app: Flask, plex_service: PlexService):
         shows = plex_service.get_shows()
         return render_template("index.html", movies=movies, shows=shows)
 
+    @bp.route("/game/cast")
+    def game_cast():
+        return render_template("games/cast.html")
+
+    @bp.route("/game/year")
+    def game_year():
+        return render_template("games/year.html")
+
+    @bp.route("/game/poster")
+    def game_poster():
+        return render_template("games/poster.html")
+
     @bp.route("/api/trivia")
     def api_trivia():
         q = trivia.random_question()

--- a/app/static/style.css
+++ b/app/static/style.css
@@ -26,3 +26,34 @@ body {
   transform: translateY(-3px);
   box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
 }
+
+.cast-circle {
+  width: 80px;
+  height: 80px;
+  border-radius: 50%;
+  background-color: #dee2e6;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: 600;
+}
+
+
+body.dark-mode {
+  background-color: #121212;
+  color: #f8f9fa;
+}
+body.dark-mode .navbar {
+  background-color: #1f1f1f;
+}
+body.dark-mode .sidebar {
+  background-color: #1f1f1f;
+  border-color: #333;
+}
+body.dark-mode .card {
+  background-color: #1f1f1f;
+  color: #f8f9fa;
+}
+body.dark-mode .cast-circle {
+  background-color: #495057;
+}

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -7,10 +7,17 @@
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
     <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}">
   </head>
-  <body class="bg-light">
+  <body>
     <nav class="navbar navbar-dark bg-dark mb-4">
-      <div class="container-fluid">
-        <span class="navbar-brand mb-0 h1">Plex Trivia</span>
+      <div class="container-fluid d-flex justify-content-between">
+        <div>
+          <button class="btn btn-outline-light me-2" id="sidebarToggle">&#9776;</button>
+          <span class="navbar-brand mb-0 h1">Plex Trivia</span>
+        </div>
+        <div class="form-check form-switch text-white">
+          <input class="form-check-input" type="checkbox" id="darkModeSwitch">
+          <label class="form-check-label" for="darkModeSwitch">Dark Mode</label>
+        </div>
       </div>
     </nav>
     <div class="container-fluid">
@@ -37,6 +44,25 @@
       </div>
     </div>
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
+    <script>
+      const sidebarToggle = document.getElementById('sidebarToggle');
+      const sidebar = document.querySelector('.sidebar');
+      sidebarToggle.addEventListener('click', () => {
+        sidebar.classList.toggle('d-none');
+      });
+
+      const switchEl = document.getElementById('darkModeSwitch');
+      const applyDark = (val) => {
+        document.body.classList.toggle('dark-mode', val);
+      };
+      const stored = localStorage.getItem('darkMode') === '1';
+      switchEl.checked = stored;
+      applyDark(stored);
+      switchEl.addEventListener('change', () => {
+        localStorage.setItem('darkMode', switchEl.checked ? '1' : '0');
+        applyDark(switchEl.checked);
+      });
+    </script>
   </body>
 </html>
 

--- a/app/templates/games/cast.html
+++ b/app/templates/games/cast.html
@@ -1,0 +1,65 @@
+{% extends 'base.html' %}
+{% block content %}
+<div class="container-fluid game-page">
+  <h2 class="text-center mb-4">Cast Reveal</h2>
+  <div id="castProgress" class="progress mb-4" style="height: 10px;">
+    <div class="progress-bar" role="progressbar" style="width:0%"></div>
+  </div>
+  <div id="castCircles" class="d-flex justify-content-center flex-wrap gap-3 mb-4"></div>
+  <div class="d-flex justify-content-center mb-3">
+    <input id="castGuessInput" class="form-control me-2" placeholder="Guess the movie" style="max-width:300px">
+    <button id="castGuessBtn" class="btn btn-primary">Guess</button>
+  </div>
+  <div id="castResult" class="text-center"></div>
+</div>
+<script>
+let castData = null;
+let revealed = 1;
+const total = 7;
+
+function updateProgress() {
+  const percent = ((revealed - 1) / total) * 100;
+  document.querySelector('#castProgress .progress-bar').style.width = `${percent}%`;
+}
+
+function renderCircles() {
+  const container = document.getElementById('castCircles');
+  container.innerHTML = '';
+  for (let i = 0; i < total; i++) {
+    const div = document.createElement('div');
+    div.className = 'cast-circle';
+    div.textContent = i < revealed && castData.cast[i] ? castData.cast[i] : '?';
+    container.appendChild(div);
+  }
+  updateProgress();
+}
+
+async function loadGame() {
+  const res = await fetch('/api/trivia/cast');
+  castData = await res.json();
+  if (!castData.cast) {
+    document.getElementById('castResult').innerText = castData.error || 'No data';
+    return;
+  }
+  renderCircles();
+}
+
+document.getElementById('castGuessBtn').addEventListener('click', () => {
+  const guess = document.getElementById('castGuessInput').value.trim().toLowerCase();
+  if (!castData) return;
+  if (guess === castData.title.toLowerCase()) {
+    document.getElementById('castResult').innerHTML = `<div class='alert alert-success'>Correct! It was ${castData.title}.</div>`;
+  } else {
+    revealed++;
+    if (revealed > total || revealed > castData.cast.length) {
+      document.getElementById('castResult').innerHTML = `<div class='alert alert-info'>Out of guesses! It was ${castData.title}.</div>`;
+      renderCircles();
+      return;
+    }
+    renderCircles();
+  }
+});
+
+loadGame();
+</script>
+{% endblock %}

--- a/app/templates/games/poster.html
+++ b/app/templates/games/poster.html
@@ -1,0 +1,51 @@
+{% extends 'base.html' %}
+{% block content %}
+<div class="container-fluid game-page text-center">
+  <h2 class="mb-4">Poster Reveal</h2>
+  <div id="posterContainer" class="mb-3"></div>
+  <button id="posterRevealBtn" class="btn btn-primary mb-2">Reveal More</button>
+  <div id="posterResult"></div>
+</div>
+<script>
+let posterData = null;
+let blur = 15;
+let count = 3;
+let words = [];
+
+async function loadPoster() {
+  const res = await fetch('/api/trivia/poster');
+  posterData = await res.json();
+  if (!posterData.poster) {
+    document.getElementById('posterResult').innerText = posterData.error || 'No data';
+    return;
+  }
+  words = posterData.summary ? posterData.summary.split(' ') : [];
+  render();
+}
+
+function render() {
+  const div = document.getElementById('posterContainer');
+  div.innerHTML = `<img id='posterImg' src='${posterData.poster}' style='max-width:100%;filter:blur(${blur}px);'>` +
+    `<p id='posterSummary' class='mt-3'>${words.slice(0,count).join(' ')}...</p>`;
+}
+
+document.getElementById('posterRevealBtn').addEventListener('click', () => {
+  if (!posterData) return;
+  if (blur > 0) {
+    blur -= 3;
+    if (blur < 0) blur = 0;
+  }
+  if (count < words.length) {
+    count += 3;
+  }
+  render();
+  document.getElementById('posterImg').style.filter = `blur(${blur}px)`;
+  if (blur === 0 && count >= words.length) {
+    document.getElementById('posterRevealBtn').disabled = true;
+    document.getElementById('posterResult').innerHTML = `<div class='alert alert-info'>Answer: ${posterData.title}</div>`;
+  }
+});
+
+loadPoster();
+</script>
+{% endblock %}

--- a/app/templates/games/year.html
+++ b/app/templates/games/year.html
@@ -1,0 +1,37 @@
+{% extends 'base.html' %}
+{% block content %}
+<div class="container-fluid game-page text-center">
+  <h2 class="mb-4">Guess the Year</h2>
+  <div id="yearQuestion" class="display-6 mb-3"></div>
+  <div class="d-flex justify-content-center mb-3">
+    <input id="yearInput" type="number" class="form-control me-2" style="max-width:200px" placeholder="Year">
+    <button id="yearGuessBtn" class="btn btn-primary">Guess</button>
+  </div>
+  <div id="yearResult"></div>
+</div>
+<script>
+let yearData = null;
+async function loadYear() {
+  const res = await fetch('/api/trivia/year');
+  yearData = await res.json();
+  if (!yearData.title) {
+    document.getElementById('yearQuestion').innerText = yearData.error || 'No data';
+    return;
+  }
+  document.getElementById('yearQuestion').innerText = `What year did ${yearData.title} release?`;
+}
+
+document.getElementById('yearGuessBtn').addEventListener('click', () => {
+  if (!yearData) return;
+  const guess = parseInt(document.getElementById('yearInput').value, 10);
+  const result = document.getElementById('yearResult');
+  if (guess === yearData.year) {
+    result.innerHTML = `<div class='alert alert-success'>Correct!</div>`;
+  } else {
+    result.innerHTML = `<div class='alert alert-info'>Nope, it was ${yearData.year}.</div>`;
+  }
+});
+
+loadYear();
+</script>
+{% endblock %}

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -8,8 +8,7 @@
       <div class="card-body">
         <h5 class="card-title">Cast Reveal Game</h5>
         <p class="card-text">Guess the movie as cast members are revealed.</p>
-        <button id="castBtn" class="btn btn-primary mt-2">Start</button>
-        <div id="castGame" class="mt-3"></div>
+        <a href="/game/cast" class="btn btn-primary mt-2">Start</a>
       </div>
     </div>
   </div>
@@ -18,8 +17,7 @@
       <div class="card-body">
         <h5 class="card-title">Guess the Year</h5>
         <p class="card-text">How well do you know release dates?</p>
-        <button id="yearBtn" class="btn btn-primary mt-2">New Question</button>
-        <div id="yearGame" class="mt-3"></div>
+        <a href="/game/year" class="btn btn-primary mt-2">Start</a>
       </div>
     </div>
   </div>
@@ -28,85 +26,10 @@
       <div class="card-body">
         <h5 class="card-title">Poster Reveal</h5>
         <p class="card-text">The image becomes clearer each round.</p>
-        <button id="posterBtn" class="btn btn-primary mt-2">Reveal Poster</button>
-        <div id="posterGame" class="mt-3 text-center"></div>
+        <a href="/game/poster" class="btn btn-primary mt-2">Start</a>
       </div>
     </div>
   </div>
 </div>
 
-<script>
-  document.getElementById('castBtn').addEventListener('click', async () => {
-    const res = await fetch('/api/trivia/cast');
-    const data = await res.json();
-    const div = document.getElementById('castGame');
-    if (data.cast) {
-      let index = 1;
-      div.innerHTML = `<div id='castList'></div><button id='revealCast' class='btn btn-sm btn-secondary mt-2'>Reveal Next</button>`;
-      const castList = document.getElementById('castList');
-      castList.innerHTML = `<span class='badge bg-info me-1'>${data.cast[0]}</span>`;
-      document.getElementById('revealCast').addEventListener('click', () => {
-        if (index < data.cast.length) {
-          castList.innerHTML += `<span class='badge bg-info me-1'>${data.cast[index]}</span>`;
-          index++;
-        } else {
-          document.getElementById('revealCast').disabled = true;
-          div.innerHTML += `<div class='mt-2 alert alert-primary'>Answer: ${data.title}</div>`;
-        }
-      });
-    } else {
-      div.innerHTML = `<div class='alert alert-warning'>${data.error}</div>`;
-    }
-  });
-
-  document.getElementById('yearBtn').addEventListener('click', async () => {
-    const res = await fetch('/api/trivia/year');
-    const data = await res.json();
-    const div = document.getElementById('yearGame');
-    if (data.title) {
-      div.innerHTML = `What year did <strong>${data.title}</strong> release? <input id='yearInput' class='form-control form-control-sm mt-2' placeholder='Enter year'><button id='yearGuess' class='btn btn-sm btn-secondary mt-2'>Guess</button><div id='yearAnswer' class='mt-2'></div>`;
-      document.getElementById('yearGuess').addEventListener('click', () => {
-        const guess = parseInt(document.getElementById('yearInput').value);
-        const ans = document.getElementById('yearAnswer');
-        if (guess === data.year) {
-          ans.innerHTML = `<span class='text-success'>Correct!</span>`;
-        } else {
-          ans.innerHTML = `<span class='text-danger'>Nope, it was ${data.year}</span>`;
-        }
-      });
-    } else {
-      div.innerHTML = `<div class='alert alert-warning'>${data.error}</div>`;
-    }
-  });
-
-  document.getElementById('posterBtn').addEventListener('click', async () => {
-    const res = await fetch('/api/trivia/poster');
-    const data = await res.json();
-    const div = document.getElementById('posterGame');
-    if (data.poster) {
-      let blur = 15;
-      const words = data.summary.split(' ');
-      let count = 3;
-      div.innerHTML = `<img id='posterImg' src='${data.poster}' style='max-width:100%;filter:blur(${blur}px);'><p id='posterSummary' class='mt-2'>${words.slice(0,count).join(' ')}...</p><button id='posterReveal' class='btn btn-sm btn-secondary mt-2'>Reveal More</button><div id='posterAnswer' class='mt-2'></div>`;
-      const img = document.getElementById('posterImg');
-      document.getElementById('posterReveal').addEventListener('click', () => {
-        if (blur > 0) {
-          blur -= 3;
-          if (blur < 0) blur = 0;
-          img.style.filter = `blur(${blur}px)`;
-        }
-        if (count < words.length) {
-          count += 3;
-          document.getElementById('posterSummary').innerText = words.slice(0,count).join(' ') + '...';
-        }
-        if (blur === 0 && count >= words.length) {
-          document.getElementById('posterReveal').disabled = true;
-          document.getElementById('posterAnswer').innerHTML = `Answer: ${data.title}`;
-        }
-      });
-    } else {
-      div.innerHTML = `<div class='alert alert-warning'>${data.error}</div>`;
-    }
-  });
-</script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- add dedicated pages for Cast Reveal, Guess the Year and Poster Reveal
- add routes for the new pages
- overhaul base layout with sidebar toggle and dark mode switch
- rework home page cards to link to new games
- add styling and scripts for a modern full-screen game UI

## Testing
- `python -m py_compile app/routes.py app/plex_service.py app/trivia.py app/__init__.py`

------
https://chatgpt.com/codex/tasks/task_e_68547e2989b48331b59b3bae3494eea7