### PR TITLE
Improve dark mode toggle and poster guessing

### DIFF
--- a/app/static/base.js
+++ b/app/static/base.js
@@ -14,13 +14,14 @@ function initLayoutControls() {
     localStorage.setItem('darkMode', enabled ? '1' : '0');
   }
 
-  toggleDark.addEventListener('click', () => {
-    setDark(!body.classList.contains('dark-mode'));
+  toggleDark.addEventListener('change', () => {
+    setDark(toggleDark.checked);
   });
 
   // load saved mode
   if (localStorage.getItem('darkMode') === '1') {
     body.classList.add('dark-mode');
+    toggleDark.checked = true;
   }
 }
 

--- a/app/static/poster.js
+++ b/app/static/poster.js
@@ -5,9 +5,22 @@ document.addEventListener('DOMContentLoaded', () => {
   const summary = document.getElementById('posterSummary');
   const revealBtn = document.getElementById('posterReveal');
   const result = document.getElementById('posterAnswer');
+  const guessBtn = document.getElementById('posterGuessBtn');
+  const guessInput = document.getElementById('posterGuessInput');
+  const titleList = document.getElementById('posterTitleList');
   let data = null;
   let blur = 15;
   let count = 3;
+
+  async function loadTitles() {
+    const res = await fetch('/api/library');
+    const library = await res.json();
+    [...library.movies, ...library.shows].forEach(t => {
+      const opt = document.createElement('option');
+      opt.value = t;
+      titleList.appendChild(opt);
+    });
+  }
 
   async function init() {
     const res = await fetch('/api/trivia/poster');
@@ -32,8 +45,24 @@ document.addEventListener('DOMContentLoaded', () => {
     if (blur === 0 && count >= words.length) {
       revealBtn.disabled = true;
       result.textContent = `Answer: ${data.title}`;
+      guessBtn.disabled = true;
+      guessInput.disabled = true;
     }
   });
 
+  guessBtn.addEventListener('click', () => {
+    const guess = guessInput.value.trim().toLowerCase();
+    if (!data) return;
+    if (guess === data.title.toLowerCase()) {
+      result.innerHTML = `<div class='alert alert-success'>Correct! It was ${data.title}</div>`;
+      revealBtn.disabled = true;
+      guessBtn.disabled = true;
+      guessInput.disabled = true;
+    } else {
+      result.innerHTML = `<div class='alert alert-danger'>Try again!</div>`;
+    }
+  });
+
+  loadTitles();
   init();
 });

--- a/app/static/style.css
+++ b/app/static/style.css
@@ -7,10 +7,6 @@ body.dark-mode {
   color: #e0e0e0;
 }
 
-body.dark-mode .navbar {
-  background-color: #1f1f1f;
-}
-
 body.dark-mode .sidebar {
   background-color: #1f1f1f;
   border-color: #333;
@@ -26,6 +22,8 @@ body.dark-mode .card {
   min-height: 100vh;
   border-right: 1px solid #dee2e6;
   transition: width 0.3s ease;
+  display: flex;
+  flex-direction: column;
 }
 
 .sidebar.collapsed {
@@ -79,4 +77,31 @@ body.dark-mode .card {
 body.dark-mode .cast-circle {
   background-color: #343a40;
   color: #e0e0e0;
+}
+
+body.dark-mode .nav-link {
+  color: #e0e0e0;
+}
+
+body.dark-mode .nav-link:hover {
+  background-color: #343a40;
+}
+
+body.dark-mode .card-hover:hover {
+  box-shadow: 0 4px 8px rgba(255, 255, 255, 0.1);
+}
+
+body.dark-mode .progress {
+  background-color: #343a40;
+}
+
+body.dark-mode .form-control {
+  background-color: #343a40;
+  color: #fff;
+  border-color: #555;
+}
+
+body.dark-mode .btn-primary {
+  background-color: #0069d9;
+  border-color: #0069d9;
 }

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -8,21 +8,12 @@
     <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}">
   </head>
   <body class="bg-light">
-    <nav class="navbar navbar-dark bg-dark mb-4">
-      <div class="container-fluid d-flex align-items-center">
-        <button id="toggleSidebar" class="btn btn-outline-light me-2">&#9776;</button>
-        <span class="navbar-brand mb-0 h1">Plex Trivia</span>
-        <div class="ms-auto">
-          <button id="toggleDark" class="btn btn-outline-light">Dark Mode</button>
-        </div>
-      </div>
-    </nav>
     <div class="container-fluid">
       <div class="row flex-nowrap">
-        <aside class="sidebar col-12 col-md-3 col-lg-2 p-3">
-          <div class="text-center mb-4">
-            <img src="https://via.placeholder.com/80" class="rounded-circle mb-2" alt="Profile picture">
-            <h5 class="fw-bold">Guest</h5>
+        <aside class="sidebar col-12 col-md-3 col-lg-2 p-3 d-flex flex-column">
+          <div class="d-flex align-items-center justify-content-between mb-3">
+            <button id="toggleSidebar" class="btn btn-outline-secondary me-2">&#9776;</button>
+            <a href="{{ url_for('main.index') }}" class="text-decoration-none"><h5 class="fw-bold mb-0">Media Library Trivia</h5></a>
           </div>
           <ul class="nav flex-column mb-4">
             <li class="nav-item"><a class="nav-link" href="#">Profile</a></li>
@@ -34,6 +25,12 @@
             <li class="nav-item"><a class="nav-link" href="#">TV Trivia</a></li>
             <li class="nav-item"><a class="nav-link" href="#">Miscellaneous</a></li>
           </ul>
+          <div class="mt-auto">
+            <div class="form-check form-switch">
+              <input class="form-check-input" type="checkbox" id="toggleDark">
+              <label class="form-check-label" for="toggleDark">Dark Mode</label>
+            </div>
+          </div>
         </aside>
         <main class="col py-4">
           {% block content %}{% endblock %}

--- a/app/templates/game_poster.html
+++ b/app/templates/game_poster.html
@@ -5,7 +5,12 @@
   <h2 class="mb-4">Poster Reveal</h2>
   <img id="posterImg" style="max-width:100%;filter:blur(15px);" class="mb-3" />
   <p id="posterSummary" class="mb-3"></p>
-  <button id="posterReveal" class="btn btn-primary">Reveal More</button>
+  <button id="posterReveal" class="btn btn-primary mb-3">Reveal More</button>
+  <div class="input-group mb-3 w-50 mx-auto">
+    <input id="posterGuessInput" list="posterTitleList" class="form-control" placeholder="Search titles">
+    <datalist id="posterTitleList"></datalist>
+    <button class="btn btn-primary" id="posterGuessBtn">Guess</button>
+  </div>
   <div id="posterAnswer" class="mt-3"></div>
 </div>
 <script src="{{ url_for('static', filename='poster.js') }}"></script>


### PR DESCRIPTION
## Summary
- remove nav bar and keep controls in sidebar
- place dark mode toggle switch at bottom of sidebar and make it persist
- dark theme now covers nav links, progress bars and form controls
- add guess input to Poster Reveal game

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685480ebed8083318a2eebf1584eab9a