### PR TITLE
Improve UI layout and poster game

### DIFF
--- a/app/static/base.js
+++ b/app/static/base.js
@@ -12,15 +12,18 @@ function initLayoutControls() {
   function setDark(enabled) {
     body.classList.toggle('dark-mode', enabled);
     localStorage.setItem('darkMode', enabled ? '1' : '0');
+    toggleDark.checked = enabled;
   }
 
-  toggleDark.addEventListener('click', () => {
-    setDark(!body.classList.contains('dark-mode'));
+  toggleDark.addEventListener('change', () => {
+    setDark(toggleDark.checked);
   });
 
   // load saved mode
   if (localStorage.getItem('darkMode') === '1') {
-    body.classList.add('dark-mode');
+    setDark(true);
+  } else {
+    setDark(false);
   }
 }
 

--- a/app/static/poster.js
+++ b/app/static/poster.js
@@ -5,6 +5,9 @@ document.addEventListener('DOMContentLoaded', () => {
   const summary = document.getElementById('posterSummary');
   const revealBtn = document.getElementById('posterReveal');
   const result = document.getElementById('posterAnswer');
+  const guessBtn = document.getElementById('guessBtn');
+  const guessInput = document.getElementById('guessInput');
+  const titleList = document.getElementById('titleList');
   let data = null;
   let blur = 15;
   let count = 3;
@@ -16,6 +19,16 @@ document.addEventListener('DOMContentLoaded', () => {
       img.src = data.poster;
     }
     summary.textContent = data.summary.split(' ').slice(0, count).join(' ') + '...';
+  }
+
+  async function loadTitles() {
+    const res = await fetch('/api/library');
+    const library = await res.json();
+    [...library.movies, ...library.shows].forEach(t => {
+      const opt = document.createElement('option');
+      opt.value = t;
+      titleList.appendChild(opt);
+    });
   }
 
   revealBtn.addEventListener('click', () => {
@@ -35,5 +48,18 @@ document.addEventListener('DOMContentLoaded', () => {
     }
   });
 
+  guessBtn.addEventListener('click', () => {
+    const guess = guessInput.value.trim().toLowerCase();
+    if (!data) return;
+    if (guess === data.title.toLowerCase()) {
+      result.innerHTML = `<div class='alert alert-success'>Correct! It was ${data.title}</div>`;
+      revealBtn.disabled = true;
+      guessBtn.disabled = true;
+    } else {
+      result.innerHTML = `<div class='alert alert-danger'>Try again!</div>`;
+    }
+  });
+
+  loadTitles();
   init();
 });

--- a/app/static/style.css
+++ b/app/static/style.css
@@ -7,13 +7,27 @@ body.dark-mode {
   color: #e0e0e0;
 }
 
-body.dark-mode .navbar {
-  background-color: #1f1f1f;
-}
-
 body.dark-mode .sidebar {
   background-color: #1f1f1f;
   border-color: #333;
+}
+
+body.dark-mode .sidebar .nav-link {
+  color: #e0e0e0;
+}
+
+body.dark-mode .sidebar .nav-link:hover {
+  background-color: #343a40;
+}
+
+body.dark-mode .form-control {
+  background-color: #2c2c2c;
+  color: #e0e0e0;
+  border-color: #555;
+}
+
+body.dark-mode .progress {
+  background-color: #2c2c2c;
 }
 
 body.dark-mode .card {
@@ -26,6 +40,8 @@ body.dark-mode .card {
   min-height: 100vh;
   border-right: 1px solid #dee2e6;
   transition: width 0.3s ease;
+  display: flex;
+  flex-direction: column;
 }
 
 .sidebar.collapsed {
@@ -35,6 +51,10 @@ body.dark-mode .card {
 .sidebar.collapsed .nav-link,
 .sidebar.collapsed h6,
 .sidebar.collapsed .text-center {
+  display: none;
+}
+
+.sidebar.collapsed .sidebar-bottom {
   display: none;
 }
 
@@ -74,6 +94,10 @@ body.dark-mode .card {
   align-items: center;
   justify-content: center;
   font-weight: 600;
+}
+
+.sidebar-bottom {
+  margin-top: auto;
 }
 
 body.dark-mode .cast-circle {

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -7,22 +7,15 @@
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
     <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}">
   </head>
-  <body class="bg-light">
-    <nav class="navbar navbar-dark bg-dark mb-4">
-      <div class="container-fluid d-flex align-items-center">
-        <button id="toggleSidebar" class="btn btn-outline-light me-2">&#9776;</button>
-        <span class="navbar-brand mb-0 h1">Plex Trivia</span>
-        <div class="ms-auto">
-          <button id="toggleDark" class="btn btn-outline-light">Dark Mode</button>
-        </div>
-      </div>
-    </nav>
+  <body>
     <div class="container-fluid">
       <div class="row flex-nowrap">
-        <aside class="sidebar col-12 col-md-3 col-lg-2 p-3">
+        <aside class="sidebar col-12 col-md-3 col-lg-2 p-3 d-flex flex-column">
+          <button id="toggleSidebar" class="btn btn-outline-secondary mb-3 align-self-end">&#9776;</button>
           <div class="text-center mb-4">
-            <img src="https://via.placeholder.com/80" class="rounded-circle mb-2" alt="Profile picture">
-            <h5 class="fw-bold">Guest</h5>
+            <a href="{{ url_for('main.index') }}" class="text-decoration-none">
+              <h5 class="fw-bold">Media Library Trivia</h5>
+            </a>
           </div>
           <ul class="nav flex-column mb-4">
             <li class="nav-item"><a class="nav-link" href="#">Profile</a></li>
@@ -34,6 +27,12 @@
             <li class="nav-item"><a class="nav-link" href="#">TV Trivia</a></li>
             <li class="nav-item"><a class="nav-link" href="#">Miscellaneous</a></li>
           </ul>
+          <div class="sidebar-bottom mt-auto pt-3">
+            <div class="form-check form-switch">
+              <input class="form-check-input" type="checkbox" id="toggleDark">
+              <label class="form-check-label" for="toggleDark">Dark Mode</label>
+            </div>
+          </div>
         </aside>
         <main class="col py-4">
           {% block content %}{% endblock %}

--- a/app/templates/game_poster.html
+++ b/app/templates/game_poster.html
@@ -5,7 +5,12 @@
   <h2 class="mb-4">Poster Reveal</h2>
   <img id="posterImg" style="max-width:100%;filter:blur(15px);" class="mb-3" />
   <p id="posterSummary" class="mb-3"></p>
-  <button id="posterReveal" class="btn btn-primary">Reveal More</button>
+  <button id="posterReveal" class="btn btn-primary mb-3">Reveal More</button>
+  <div class="input-group mb-3 w-50 mx-auto">
+    <input id="guessInput" list="titleList" class="form-control" placeholder="Search titles">
+    <datalist id="titleList"></datalist>
+    <button class="btn btn-primary" id="guessBtn">Guess</button>
+  </div>
   <div id="posterAnswer" class="mt-3"></div>
 </div>
 <script src="{{ url_for('static', filename='poster.js') }}"></script>

--- a/app/trivia.py
+++ b/app/trivia.py
@@ -60,4 +60,3 @@ class TriviaEngine:
             "poster": poster,
             "summary": movie.summary,
         }
-


### PR DESCRIPTION
## Summary
- drop navbar and move controls into sidebar
- style sidebar and add dark mode toggle switch
- add guess input to poster reveal game
- support dark mode switch via checkbox state persistence

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `black --check .`


------
https://chatgpt.com/codex/tasks/task_e_685480ebed8083318a2eebf1584eab9a