### PR TITLE
UI improvements and poster guessing

### DIFF
--- a/app/static/base.js
+++ b/app/static/base.js
@@ -2,7 +2,7 @@
 function initLayoutControls() {
   const sidebar = document.querySelector('.sidebar');
   const toggleSidebar = document.getElementById('toggleSidebar');
-  const toggleDark = document.getElementById('toggleDark');
+  const darkSwitch = document.getElementById('darkSwitch');
   const body = document.body;
 
   toggleSidebar.addEventListener('click', () => {
@@ -12,16 +12,16 @@ function initLayoutControls() {
   function setDark(enabled) {
     body.classList.toggle('dark-mode', enabled);
     localStorage.setItem('darkMode', enabled ? '1' : '0');
+    darkSwitch.checked = enabled;
   }
 
-  toggleDark.addEventListener('click', () => {
-    setDark(!body.classList.contains('dark-mode'));
+  darkSwitch.addEventListener('change', () => {
+    setDark(darkSwitch.checked);
   });
 
   // load saved mode
-  if (localStorage.getItem('darkMode') === '1') {
-    body.classList.add('dark-mode');
-  }
+  const saved = localStorage.getItem('darkMode') === '1';
+  setDark(saved);
 }
 
 document.addEventListener('DOMContentLoaded', initLayoutControls);

--- a/app/static/poster.js
+++ b/app/static/poster.js
@@ -5,6 +5,9 @@ document.addEventListener('DOMContentLoaded', () => {
   const summary = document.getElementById('posterSummary');
   const revealBtn = document.getElementById('posterReveal');
   const result = document.getElementById('posterAnswer');
+  const guessInput = document.getElementById('posterGuessInput');
+  const guessBtn = document.getElementById('posterGuessBtn');
+  const titleList = document.getElementById('titleList');
   let data = null;
   let blur = 15;
   let count = 3;
@@ -16,6 +19,16 @@ document.addEventListener('DOMContentLoaded', () => {
       img.src = data.poster;
     }
     summary.textContent = data.summary.split(' ').slice(0, count).join(' ') + '...';
+  }
+
+  async function loadTitles() {
+    const res = await fetch('/api/library');
+    const library = await res.json();
+    [...library.movies, ...library.shows].forEach(t => {
+      const opt = document.createElement('option');
+      opt.value = t;
+      titleList.appendChild(opt);
+    });
   }
 
   revealBtn.addEventListener('click', () => {
@@ -35,5 +48,18 @@ document.addEventListener('DOMContentLoaded', () => {
     }
   });
 
+  guessBtn.addEventListener('click', () => {
+    const guess = guessInput.value.trim().toLowerCase();
+    if (!data) return;
+    if (guess === data.title.toLowerCase()) {
+      result.innerHTML = `<div class='alert alert-success'>Correct! It was ${data.title}</div>`;
+      revealBtn.disabled = true;
+      guessBtn.disabled = true;
+    } else {
+      result.innerHTML = `<div class='alert alert-danger'>Try again!</div>`;
+    }
+  });
+
+  loadTitles();
   init();
 });

--- a/app/static/style.css
+++ b/app/static/style.css
@@ -7,10 +7,6 @@ body.dark-mode {
   color: #e0e0e0;
 }
 
-body.dark-mode .navbar {
-  background-color: #1f1f1f;
-}
-
 body.dark-mode .sidebar {
   background-color: #1f1f1f;
   border-color: #333;
@@ -21,11 +17,35 @@ body.dark-mode .card {
   color: #e0e0e0;
 }
 
+body.dark-mode .sidebar .nav-link:hover {
+  background-color: #343a40;
+}
+
+body.dark-mode .form-control {
+  background-color: #343a40;
+  color: #e0e0e0;
+  border-color: #555;
+}
+
+body.dark-mode .progress {
+  background-color: #343a40;
+}
+
+body.dark-mode .bg-light {
+  background-color: #1f1f1f !important;
+}
+
+body.dark-mode .btn-outline-secondary {
+  color: #e0e0e0;
+  border-color: #e0e0e0;
+}
+
 .sidebar {
   background-color: #f8f9fa;
   min-height: 100vh;
   border-right: 1px solid #dee2e6;
   transition: width 0.3s ease;
+  position: relative;
 }
 
 .sidebar.collapsed {
@@ -34,7 +54,8 @@ body.dark-mode .card {
 
 .sidebar.collapsed .nav-link,
 .sidebar.collapsed h6,
-.sidebar.collapsed .text-center {
+.sidebar.collapsed .text-center,
+.sidebar.collapsed .dark-switch-container {
   display: none;
 }
 
@@ -46,6 +67,13 @@ body.dark-mode .card {
 .sidebar .nav-link:hover {
   background-color: #e9ecef;
   transition: background-color 0.3s ease;
+}
+
+.dark-switch-container {
+  position: absolute;
+  bottom: 1rem;
+  left: 0;
+  width: 100%;
 }
 
 .card-hover {

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -8,21 +8,12 @@
     <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}">
   </head>
   <body class="bg-light">
-    <nav class="navbar navbar-dark bg-dark mb-4">
-      <div class="container-fluid d-flex align-items-center">
-        <button id="toggleSidebar" class="btn btn-outline-light me-2">&#9776;</button>
-        <span class="navbar-brand mb-0 h1">Plex Trivia</span>
-        <div class="ms-auto">
-          <button id="toggleDark" class="btn btn-outline-light">Dark Mode</button>
-        </div>
-      </div>
-    </nav>
     <div class="container-fluid">
       <div class="row flex-nowrap">
         <aside class="sidebar col-12 col-md-3 col-lg-2 p-3">
-          <div class="text-center mb-4">
-            <img src="https://via.placeholder.com/80" class="rounded-circle mb-2" alt="Profile picture">
-            <h5 class="fw-bold">Guest</h5>
+          <div class="d-flex justify-content-between align-items-center mb-4">
+            <a href="{{ url_for('main.index') }}" class="h4 text-decoration-none text-reset">Media Library Trivia</a>
+            <button id="toggleSidebar" class="btn btn-outline-secondary ms-2">&#9776;</button>
           </div>
           <ul class="nav flex-column mb-4">
             <li class="nav-item"><a class="nav-link" href="#">Profile</a></li>
@@ -34,6 +25,10 @@
             <li class="nav-item"><a class="nav-link" href="#">TV Trivia</a></li>
             <li class="nav-item"><a class="nav-link" href="#">Miscellaneous</a></li>
           </ul>
+          <div class="dark-switch-container form-check form-switch text-center mt-4">
+            <input class="form-check-input" type="checkbox" id="darkSwitch">
+            <label class="form-check-label" for="darkSwitch">Dark Mode</label>
+          </div>
         </aside>
         <main class="col py-4">
           {% block content %}{% endblock %}

--- a/app/templates/game_poster.html
+++ b/app/templates/game_poster.html
@@ -6,6 +6,11 @@
   <img id="posterImg" style="max-width:100%;filter:blur(15px);" class="mb-3" />
   <p id="posterSummary" class="mb-3"></p>
   <button id="posterReveal" class="btn btn-primary">Reveal More</button>
+  <div class="input-group my-3">
+    <input id="posterGuessInput" list="titleList" class="form-control" placeholder="Search titles">
+    <datalist id="titleList"></datalist>
+    <button class="btn btn-primary" id="posterGuessBtn">Guess</button>
+  </div>
   <div id="posterAnswer" class="mt-3"></div>
 </div>
 <script src="{{ url_for('static', filename='poster.js') }}"></script>


### PR DESCRIPTION
## Summary
- remove navbar and integrate sidebar header link
- move sidebar toggle inside the sidebar
- add dark-mode switch fixed at bottom of sidebar
- improve dark-mode styles
- add guessing input to poster reveal game

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685480ebed8083318a2eebf1584eab9a