### PR TITLE
Redesign sidebar and add poster guessing

### DIFF
--- a/app/static/base.js
+++ b/app/static/base.js
@@ -2,7 +2,7 @@
 function initLayoutControls() {
   const sidebar = document.querySelector('.sidebar');
   const toggleSidebar = document.getElementById('toggleSidebar');
-  const toggleDark = document.getElementById('toggleDark');
+  const toggleDark = document.getElementById('toggleDarkSwitch');
   const body = document.body;
 
   toggleSidebar.addEventListener('click', () => {
@@ -12,15 +12,17 @@ function initLayoutControls() {
   function setDark(enabled) {
     body.classList.toggle('dark-mode', enabled);
     localStorage.setItem('darkMode', enabled ? '1' : '0');
+    toggleDark.checked = enabled;
   }
 
-  toggleDark.addEventListener('click', () => {
-    setDark(!body.classList.contains('dark-mode'));
+  toggleDark.addEventListener('change', () => {
+    setDark(toggleDark.checked);
   });
 
   // load saved mode
   if (localStorage.getItem('darkMode') === '1') {
     body.classList.add('dark-mode');
+    toggleDark.checked = true;
   }
 }
 

--- a/app/static/poster.js
+++ b/app/static/poster.js
@@ -5,6 +5,9 @@ document.addEventListener('DOMContentLoaded', () => {
   const summary = document.getElementById('posterSummary');
   const revealBtn = document.getElementById('posterReveal');
   const result = document.getElementById('posterAnswer');
+  const guessInput = document.getElementById('posterGuessInput');
+  const guessBtn = document.getElementById('posterGuessBtn');
+  const titleList = document.getElementById('posterTitleList');
   let data = null;
   let blur = 15;
   let count = 3;
@@ -35,5 +38,28 @@ document.addEventListener('DOMContentLoaded', () => {
     }
   });
 
+  guessBtn.addEventListener('click', () => {
+    const guess = guessInput.value.trim().toLowerCase();
+    if (!data) return;
+    if (guess === data.title.toLowerCase()) {
+      result.innerHTML = `<div class='alert alert-success'>Correct! It was ${data.title}</div>`;
+      revealBtn.disabled = true;
+      guessBtn.disabled = true;
+    } else {
+      result.innerHTML = `<div class='alert alert-danger'>Try again!</div>`;
+    }
+  });
+
+  async function loadTitles() {
+    const res = await fetch('/api/library');
+    const library = await res.json();
+    [...library.movies, ...library.shows].forEach(t => {
+      const opt = document.createElement('option');
+      opt.value = t;
+      titleList.appendChild(opt);
+    });
+  }
+
+  loadTitles();
   init();
 });

--- a/app/static/style.css
+++ b/app/static/style.css
@@ -21,6 +21,25 @@ body.dark-mode .card {
   color: #e0e0e0;
 }
 
+body.dark-mode .form-control {
+  background-color: #333;
+  border-color: #555;
+  color: #e0e0e0;
+}
+
+body.dark-mode .progress {
+  background-color: #333;
+}
+
+body.dark-mode .sidebar .nav-link {
+  color: #ccc;
+}
+
+body.dark-mode .sidebar .nav-link:hover {
+  background-color: #333;
+}
+
+
 .sidebar {
   background-color: #f8f9fa;
   min-height: 100vh;

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -8,21 +8,12 @@
     <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}">
   </head>
   <body class="bg-light">
-    <nav class="navbar navbar-dark bg-dark mb-4">
-      <div class="container-fluid d-flex align-items-center">
-        <button id="toggleSidebar" class="btn btn-outline-light me-2">&#9776;</button>
-        <span class="navbar-brand mb-0 h1">Plex Trivia</span>
-        <div class="ms-auto">
-          <button id="toggleDark" class="btn btn-outline-light">Dark Mode</button>
-        </div>
-      </div>
-    </nav>
     <div class="container-fluid">
       <div class="row flex-nowrap">
-        <aside class="sidebar col-12 col-md-3 col-lg-2 p-3">
-          <div class="text-center mb-4">
-            <img src="https://via.placeholder.com/80" class="rounded-circle mb-2" alt="Profile picture">
-            <h5 class="fw-bold">Guest</h5>
+        <aside class="sidebar col-12 col-md-3 col-lg-2 p-3 position-relative">
+          <div class="d-flex justify-content-between align-items-center mb-4">
+            <button id="toggleSidebar" class="btn btn-outline-secondary me-2">&#9776;</button>
+            <a href="{{ url_for('main.index') }}" class="fw-bold text-decoration-none">Media Library Trivia</a>
           </div>
           <ul class="nav flex-column mb-4">
             <li class="nav-item"><a class="nav-link" href="#">Profile</a></li>
@@ -34,6 +25,10 @@
             <li class="nav-item"><a class="nav-link" href="#">TV Trivia</a></li>
             <li class="nav-item"><a class="nav-link" href="#">Miscellaneous</a></li>
           </ul>
+          <div class="form-check form-switch dark-toggle position-absolute bottom-0 start-0 w-100 px-3 pb-3">
+            <input class="form-check-input" type="checkbox" id="toggleDarkSwitch">
+            <label class="form-check-label" for="toggleDarkSwitch">Dark Mode</label>
+          </div>
         </aside>
         <main class="col py-4">
           {% block content %}{% endblock %}

--- a/app/templates/game_poster.html
+++ b/app/templates/game_poster.html
@@ -6,6 +6,11 @@
   <img id="posterImg" style="max-width:100%;filter:blur(15px);" class="mb-3" />
   <p id="posterSummary" class="mb-3"></p>
   <button id="posterReveal" class="btn btn-primary">Reveal More</button>
+  <div class="input-group my-3 w-50 mx-auto">
+    <input id="posterGuessInput" list="posterTitleList" class="form-control" placeholder="Search titles">
+    <datalist id="posterTitleList"></datalist>
+    <button class="btn btn-primary" id="posterGuessBtn">Guess</button>
+  </div>
   <div id="posterAnswer" class="mt-3"></div>
 </div>
 <script src="{{ url_for('static', filename='poster.js') }}"></script>


### PR DESCRIPTION
## Summary
- remove navbar and move sidebar toggle inside the sidebar
- add permanent dark mode switch at the bottom of the sidebar
- style inputs and progress bars for dark mode
- provide search/guess controls for Poster Reveal game

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685480ebed8083318a2eebf1584eab9a