### PR TITLE
Add env-based configuration for Plex and port

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,14 +16,14 @@ A template for an Unraid-ready application that turns your Plex library into a t
 - A Plex API token and the base URL of your Plex server
 
 ## Configuration
-The application reads two environment variables:
+The application reads a few environment variables:
 
 ```
 PLEX_BASE_URL=<http://your.plex.ip:port>
 PLEX_TOKEN=<your_plex_token>
+HOST_PORT=<port_for_web_ui>
 ```
-
-These can be supplied in `docker-compose.yml` or directly in your environment.
+These can be supplied in `docker-compose.yml` or directly in your environment. `HOST_PORT` controls which port the web interface listens on.
 
 ## Running with Docker
 
@@ -31,7 +31,8 @@ These can be supplied in `docker-compose.yml` or directly in your environment.
 docker compose up --build
 ```
 
-The web interface will be available on `http://localhost:8080` by default.
+Ensure that `PLEX_BASE_URL`, `PLEX_TOKEN` and `HOST_PORT` are set in your environment or an `.env` file before starting the stack.
+The web interface will be available on `http://localhost:${HOST_PORT}`. By default this is `8080`.
 
 ## Development
 
@@ -44,7 +45,8 @@ source venv/bin/activate
 pip install -r requirements.txt
 export PLEX_BASE_URL=http://your.plex.ip:port
 export PLEX_TOKEN=your_token
-flask --app app:create_app run
+export HOST_PORT=8080
+flask --app app:create_app run --port $HOST_PORT
 ```
 
 or, alternative on Windows:
@@ -55,7 +57,8 @@ venv\Scripts\activate
 pip install -r requirements.txt
 set PLEX_BASE_URL=http://your.plex.ip:port
 set PLEX_TOKEN=your_token
-flask --app app:create_app run
+set HOST_PORT=8080
+flask --app app:create_app run --port %HOST_PORT%
 ```
 
 ## License

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,8 +3,8 @@ services:
   trivia:
     build: .
     ports:
-      - "8080:5000"
+      - "${HOST_PORT:-8080}:${HOST_PORT:-8080}"
     environment:
-      - PLEX_BASE_URL=http://your.plex.ip:32400
-      - PLEX_TOKEN=your_token
-
+      - PLEX_BASE_URL=${PLEX_BASE_URL}
+      - PLEX_TOKEN=${PLEX_TOKEN}
+      - FLASK_RUN_PORT=${HOST_PORT:-8080}

--- a/env.example
+++ b/env.example
@@ -1,3 +1,5 @@
 # Plex Media Server Configuration
 PLEX_BASE_URL=http://localhost:32400
-PLEX_TOKEN=your_plex_token_here 
+PLEX_TOKEN=your_plex_token_here
+# Port for the Flask API
+HOST_PORT=8080


### PR DESCRIPTION
## Summary
- let docker-compose use env vars for Plex URL, token, and port
- document new HOST_PORT usage
- add example `.env` file

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685495368cdc8331b677470cfe03a6cd