### PR TITLE
Fix Docker image repo reference

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -20,4 +20,4 @@ jobs:
         with:
           context: .
           push: true
-          tags: chanzer0/media-server-trivia:latest
+          tags: chanzero/media-server-trivia:latest

--- a/README.md
+++ b/README.md
@@ -40,11 +40,11 @@ The web interface will be available on `http://localhost:${HOST_PORT}`. By defau
 ## Docker Image
 
 Every push to the `main` branch automatically builds a Docker image and publishes
-it to Docker Hub as `chanzer0/media-server-trivia:latest`. You can pull it
+it to Docker Hub as `chanzero/media-server-trivia:latest`. You can pull it
 directly:
 
 ```bash
-docker pull chanzer0/media-server-trivia:latest
+docker pull chanzero/media-server-trivia:latest
 ```
 
 The image expects the same environment variables as the compose file.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3'
 services:
   trivia:
-    image: chanzer0/media-server-trivia:latest
+    image: chanzero/media-server-trivia:latest
     build: .
     ports:
       - "${HOST_PORT:-5054}:${HOST_PORT:-5054}"


### PR DESCRIPTION
## Summary
- update workflow image tag path
- update docker-compose image path
- fix README instructions for docker hub repo name

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68549f6c1ea48331ae52ac68435559a3