### PR TITLE
Fetch TMDb metadata using Plex GUIDs

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ A template for an Unraid-ready application that turns your Plex library into a t
   - Guess the Release Year
   - Poster Reveal Challenge
 - Dockerized for easy deployment on Unraid or any Docker host
+- Retrieves additional metadata from TMDb using the TMDb GUIDs stored in your Plex library
 
 ## Requirements
 - Python 3.11 (for development) or Docker

--- a/app/routes.py
+++ b/app/routes.py
@@ -7,7 +7,7 @@ from .trivia import TriviaEngine
 # kick build
 def init_routes(app: Flask, plex_service: PlexService, tmdb_service: TMDbService):
     bp = Blueprint("main", __name__)
-    trivia = TriviaEngine(plex_service)
+    trivia = TriviaEngine(plex_service, tmdb_service)
 
     @bp.route("/")
     def index():

--- a/app/trivia.py
+++ b/app/trivia.py
@@ -2,10 +2,30 @@ import random
 
 
 class TriviaEngine:
-    """Generates trivia questions from Plex media."""
+    """Generates trivia questions from Plex media and TMDb metadata."""
 
-    def __init__(self, plex_service):
+    def __init__(self, plex_service, tmdb_service=None):
         self.plex = plex_service
+        self.tmdb = tmdb_service
+
+    def _get_tmdb_details(self, movie):
+        """Return TMDb metadata for the given Plex movie."""
+        if not self.tmdb:
+            return None
+
+        tmdb_id = None
+        for guid in getattr(movie, "guids", []):
+            try:
+                gid = getattr(guid, "id", "")
+                if isinstance(gid, str) and gid.startswith("tmdb://"):
+                    tmdb_id = int(gid.split("tmdb://", 1)[1])
+                    break
+            except Exception:
+                continue
+
+        if tmdb_id:
+            return self.tmdb.get_movie_details(tmdb_id)
+        return None
 
     def _random_movie(self):
         """Return a random movie from the Plex library."""
@@ -19,7 +39,8 @@ class TriviaEngine:
         if not movie:
             return None
         question = f"Which movie features '{movie}'?"
-        return {"question": question, "answer": movie}
+        tmdb = self._get_tmdb_details(movie)
+        return {"question": question, "answer": movie, "tmdb": tmdb}
 
     def cast_reveal(self):
         """Return the top few cast members for a random movie."""
@@ -31,14 +52,16 @@ class TriviaEngine:
         except Exception:
             cast = []
 
-        return {"title": movie.title, "cast": cast}
+        tmdb = self._get_tmdb_details(movie)
+        return {"title": movie.title, "cast": cast, "tmdb": tmdb}
 
     def guess_year(self):
         """Return the title and year for a random movie."""
         movie = self._random_movie()
         if not movie:
             return None
-        return {"title": movie.title, "year": movie.year, "summary": movie.summary}
+        tmdb = self._get_tmdb_details(movie)
+        return {"title": movie.title, "year": movie.year, "summary": movie.summary, "tmdb": tmdb}
 
     def poster_reveal(self):
         """Return poster and summary information for a random movie."""
@@ -59,4 +82,5 @@ class TriviaEngine:
             "title": movie.title,
             "poster": poster,
             "summary": movie.summary,
+            "tmdb": self._get_tmdb_details(movie),
         }


### PR DESCRIPTION
## Summary
- integrate TMDb data in trivia engine
- parse tmdb:// GUIDs from Plex movies
- return TMDb details with trivia API responses
- document TMDb metadata feature

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6861b3880670833199d655c887b439ee