### PR TITLE
Improve trivia UI with TMDb info

### DIFF
--- a/app/static/cast.js
+++ b/app/static/cast.js
@@ -7,6 +7,8 @@ document.addEventListener('DOMContentLoaded', () => {
   const guessInput = document.getElementById('guessInput');
   const result = document.getElementById('result');
   const titleList = document.getElementById('titleList');
+  const posterImg = document.getElementById('moviePoster');
+  const tagline = document.getElementById('movieTagline');
   let data = null;
   let round = 1;
 
@@ -29,10 +31,24 @@ document.addEventListener('DOMContentLoaded', () => {
     const res = await fetch('/api/trivia/cast');
     data = await res.json();
     icons.innerHTML = '';
+    posterImg.src = data.poster || '';
+    tagline.textContent = data.tagline || '';
     for (let i = 0; i < 7; i++) {
       const d = document.createElement('div');
       d.className = 'cast-circle';
-      d.textContent = i === 0 && data.cast.length > 0 ? data.cast[0] : '?';
+      if (i === 0 && data.cast.length > 0) {
+        const actor = data.cast[0];
+        if (actor.profile) {
+          const img = document.createElement('img');
+          img.src = actor.profile;
+          img.className = 'img-fluid rounded-circle';
+          d.appendChild(img);
+        } else {
+          d.textContent = actor.name;
+        }
+      } else {
+        d.textContent = '?';
+      }
       icons.appendChild(d);
     }
     updateProgress();
@@ -47,7 +63,17 @@ document.addEventListener('DOMContentLoaded', () => {
     } else {
       round++;
       if (round <= data.cast.length) {
-        document.querySelectorAll('.cast-circle')[round-1].textContent = data.cast[round-1];
+        const circle = document.querySelectorAll('.cast-circle')[round-1];
+        const actor = data.cast[round-1];
+        circle.textContent = '';
+        if (actor.profile) {
+          const img = document.createElement('img');
+          img.src = actor.profile;
+          img.className = 'img-fluid rounded-circle';
+          circle.appendChild(img);
+        } else {
+          circle.textContent = actor.name;
+        }
         result.innerHTML = `<div class='alert alert-danger'>Try again!</div>`;
       } else {
         result.innerHTML = `<div class='alert alert-info'>Out of guesses. It was ${data.title}</div>`;

--- a/app/static/poster.js
+++ b/app/static/poster.js
@@ -2,6 +2,7 @@
 
 document.addEventListener('DOMContentLoaded', () => {
   const img = document.getElementById('posterImg');
+  const tagline = document.getElementById('posterTagline');
   const summary = document.getElementById('posterSummary');
   const revealBtn = document.getElementById('posterReveal');
   const result = document.getElementById('posterAnswer');
@@ -18,6 +19,7 @@ document.addEventListener('DOMContentLoaded', () => {
     if (data.poster) {
       img.src = data.poster;
     }
+    tagline.textContent = data.tagline || '';
     summary.textContent = data.summary.split(' ').slice(0, count).join(' ') + '...';
   }
 

--- a/app/static/style.css
+++ b/app/static/style.css
@@ -107,6 +107,7 @@ body.dark-mode .card {
   align-items: center;
   justify-content: center;
   font-weight: 600;
+  overflow: hidden;
 }
 
 .sidebar-bottom {
@@ -116,4 +117,10 @@ body.dark-mode .card {
 body.dark-mode .cast-circle {
   background-color: #343a40;
   color: #e0e0e0;
+}
+
+.cast-circle img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
 }

--- a/app/static/year.js
+++ b/app/static/year.js
@@ -5,6 +5,8 @@ document.addEventListener('DOMContentLoaded', () => {
   const guessInput = document.getElementById('yearInput');
   const guessBtn = document.getElementById('yearGuess');
   const result = document.getElementById('yearResult');
+  const posterImg = document.getElementById('yearPoster');
+  const tagline = document.getElementById('yearTagline');
   let data = null;
 
   async function newQuestion() {
@@ -13,6 +15,8 @@ document.addEventListener('DOMContentLoaded', () => {
     question.textContent = `What year did ${data.title} release?`;
     guessInput.value = '';
     result.textContent = '';
+    posterImg.src = data.poster || '';
+    tagline.textContent = data.tagline || '';
   }
 
   guessBtn.addEventListener('click', () => {

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -5,6 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>Plex Trivia</title>
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.10.5/font/bootstrap-icons.css" rel="stylesheet">
     <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}">
   </head>
   <body>

--- a/app/templates/game_cast.html
+++ b/app/templates/game_cast.html
@@ -3,6 +3,8 @@
 {% block content %}
 <div class="game-container text-center">
   <h2 class="mb-4">Cast Reveal</h2>
+  <img id="moviePoster" class="mb-2" style="max-width:200px;" />
+  <p id="movieTagline" class="mb-2 fst-italic"></p>
   <div class="progress mb-4" style="height:8px;">
     <div id="roundProgress" class="progress-bar" role="progressbar" aria-valuenow="1" aria-valuemin="0" aria-valuemax="7" style="width:14%"></div>
   </div>

--- a/app/templates/game_poster.html
+++ b/app/templates/game_poster.html
@@ -4,6 +4,7 @@
 <div class="game-container text-center">
   <h2 class="mb-4">Poster Reveal</h2>
   <img id="posterImg" style="max-width:100%;filter:blur(15px);" class="mb-3" />
+  <p id="posterTagline" class="mb-2 fst-italic"></p>
   <p id="posterSummary" class="mb-3"></p>
   <button id="posterReveal" class="btn btn-primary mb-3">Reveal More</button>
   <div class="input-group mb-3 w-50 mx-auto">

--- a/app/templates/game_year.html
+++ b/app/templates/game_year.html
@@ -3,6 +3,8 @@
 {% block content %}
 <div class="game-container text-center">
   <h2 class="mb-4" id="yearQuestion"></h2>
+  <img id="yearPoster" class="mb-2" style="max-width:200px;" />
+  <p id="yearTagline" class="mb-2 fst-italic"></p>
   <div class="input-group mb-3 w-50 mx-auto">
     <input id="yearInput" class="form-control" placeholder="Enter year">
     <button class="btn btn-primary" id="yearGuess">Guess</button>

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -5,7 +5,8 @@
   <div class="col-12 col-md-6 col-lg-4">
     <div class="card card-hover h-100">
       <div class="card-body text-center">
-        <h5 class="card-title">Cast Reveal Game</h5>
+        <i class="bi bi-person-video2 fs-1 text-secondary"></i>
+        <h5 class="card-title mt-2">Cast Reveal Game</h5>
         <p class="card-text">Guess the movie as cast members are revealed.</p>
         <a href="{{ url_for('main.cast_game_page') }}" class="btn btn-primary mt-2">Play</a>
       </div>
@@ -14,7 +15,8 @@
   <div class="col-12 col-md-6 col-lg-4">
     <div class="card card-hover h-100">
       <div class="card-body text-center">
-        <h5 class="card-title">Guess the Year</h5>
+        <i class="bi bi-calendar-event fs-1 text-secondary"></i>
+        <h5 class="card-title mt-2">Guess the Year</h5>
         <p class="card-text">How well do you know release dates?</p>
         <a href="{{ url_for('main.year_game_page') }}" class="btn btn-primary mt-2">Play</a>
       </div>
@@ -23,7 +25,8 @@
   <div class="col-12 col-md-6 col-lg-4">
     <div class="card card-hover h-100">
       <div class="card-body text-center">
-        <h5 class="card-title">Poster Reveal</h5>
+        <i class="bi bi-image fs-1 text-secondary"></i>
+        <h5 class="card-title mt-2">Poster Reveal</h5>
         <p class="card-text">The image becomes clearer each round.</p>
         <a href="{{ url_for('main.poster_game_page') }}" class="btn btn-primary mt-2">Play</a>
       </div>

--- a/app/tmdb_service.py
+++ b/app/tmdb_service.py
@@ -9,6 +9,10 @@ class TMDbService:
     def __init__(self, api_key: str | None):
         self.api_key = api_key
         self.client = TMDb(key=api_key) if api_key else None
+        # Base URL for constructing image links. This matches the default
+        # path structure provided by TMDb. The image sizes vary but a medium
+        # size works well for our trivia UI.
+        self.image_base = "https://image.tmdb.org/t/p/"
 
     def get_movie_details(self, movie_id: int):
         """Return details for a movie by TMDb id."""
@@ -29,3 +33,19 @@ class TMDbService:
         except Exception as e:
             print(f"Failed to search movies: {e}")
             return []
+
+    def get_movie_credits(self, movie_id: int):
+        """Return cast/crew credits for a movie."""
+        if not self.client:
+            return None
+        try:
+            return self.client.movie(movie_id).credits()
+        except Exception as e:
+            print(f"Failed to fetch movie credits: {e}")
+            return None
+
+    def build_image_url(self, path: str | None, size: str = "w342") -> str | None:
+        """Return a full image URL for the given TMDb image path."""
+        if not path:
+            return None
+        return f"{self.image_base}{size}{path}"

--- a/app/trivia.py
+++ b/app/trivia.py
@@ -8,23 +8,33 @@ class TriviaEngine:
         self.plex = plex_service
         self.tmdb = tmdb_service
 
+    def _get_tmdb_id(self, movie):
+        """Extract the TMDb id from a Plex movie."""
+        for guid in getattr(movie, "guids", []):
+            try:
+                gid = getattr(guid, "id", "")
+                if isinstance(gid, str) and gid.startswith("tmdb://"):
+                    return int(gid.split("tmdb://", 1)[1])
+            except Exception:
+                continue
+        return None
+
     def _get_tmdb_details(self, movie):
         """Return TMDb metadata for the given Plex movie."""
         if not self.tmdb:
             return None
 
-        tmdb_id = None
-        for guid in getattr(movie, "guids", []):
-            try:
-                gid = getattr(guid, "id", "")
-                if isinstance(gid, str) and gid.startswith("tmdb://"):
-                    tmdb_id = int(gid.split("tmdb://", 1)[1])
-                    break
-            except Exception:
-                continue
-
+        tmdb_id = self._get_tmdb_id(movie)
         if tmdb_id:
             return self.tmdb.get_movie_details(tmdb_id)
+        return None
+
+    def _get_tmdb_credits(self, movie):
+        if not self.tmdb:
+            return None
+        tmdb_id = self._get_tmdb_id(movie)
+        if tmdb_id:
+            return self.tmdb.get_movie_credits(tmdb_id)
         return None
 
     def _random_movie(self):
@@ -48,20 +58,53 @@ class TriviaEngine:
         if not movie:
             return None
         try:
-            cast = [actor.tag for actor in movie.actors][:7]
+            cast_names = [actor.tag for actor in movie.actors][:7]
         except Exception:
-            cast = []
+            cast_names = []
 
-        tmdb = self._get_tmdb_details(movie)
-        return {"title": movie.title, "cast": cast, "tmdb": tmdb}
+        tmdb_details = self._get_tmdb_details(movie)
+        credits = self._get_tmdb_credits(movie)
+        cast = []
+        if credits and hasattr(credits, "cast"):
+            for person in list(getattr(credits, "cast"))[:7]:
+                name = getattr(person, "name", None) or getattr(person, "original_name", "")
+                profile = self.tmdb.build_image_url(getattr(person, "profile_path", None), "w185") if self.tmdb else None
+                cast.append({"name": name, "profile": profile})
+        else:
+            for n in cast_names:
+                cast.append({"name": n, "profile": None})
+
+        poster = None
+        if tmdb_details and hasattr(tmdb_details, "poster_path"):
+            poster = self.tmdb.build_image_url(getattr(tmdb_details, "poster_path", None))
+
+        tagline = getattr(tmdb_details, "tagline", None) if tmdb_details else None
+
+        return {
+            "title": movie.title,
+            "cast": cast,
+            "poster": poster,
+            "tagline": tagline,
+        }
 
     def guess_year(self):
         """Return the title and year for a random movie."""
         movie = self._random_movie()
         if not movie:
             return None
-        tmdb = self._get_tmdb_details(movie)
-        return {"title": movie.title, "year": movie.year, "summary": movie.summary, "tmdb": tmdb}
+        tmdb_details = self._get_tmdb_details(movie)
+        poster = None
+        tagline = None
+        if tmdb_details:
+            poster = self.tmdb.build_image_url(getattr(tmdb_details, "poster_path", None)) if self.tmdb else None
+            tagline = getattr(tmdb_details, "tagline", None)
+        return {
+            "title": movie.title,
+            "year": movie.year,
+            "summary": movie.summary,
+            "poster": poster,
+            "tagline": tagline,
+        }
 
     def poster_reveal(self):
         """Return poster and summary information for a random movie."""
@@ -78,9 +121,13 @@ class TriviaEngine:
             except Exception:
                 poster = None
 
+        tmdb_details = self._get_tmdb_details(movie)
+        if not poster and tmdb_details:
+            poster = self.tmdb.build_image_url(getattr(tmdb_details, "poster_path", None)) if self.tmdb else None
+        tagline = getattr(tmdb_details, "tagline", None) if tmdb_details else None
         return {
             "title": movie.title,
             "poster": poster,
             "summary": movie.summary,
-            "tmdb": self._get_tmdb_details(movie),
+            "tagline": tagline,
         }


### PR DESCRIPTION
## Summary
- pull poster images and cast/crew from TMDb
- show movie poster and tagline in trivia pages
- display actor images in the cast game
- add icons to the index page and include Bootstrap Icons
- style updates for cast images

## Testing
- `python -m compileall -q app`

------
https://chatgpt.com/codex/tasks/task_e_6861b5027bd0833185997a1db9379cd9