### PR TITLE
Enhance trivia UI with TMDb info

### DIFF
--- a/app/static/cast.js
+++ b/app/static/cast.js
@@ -7,8 +7,11 @@ document.addEventListener('DOMContentLoaded', () => {
   const guessInput = document.getElementById('guessInput');
   const result = document.getElementById('result');
   const titleList = document.getElementById('titleList');
+  const posterImg = document.getElementById('moviePoster');
+  const tagline = document.getElementById('movieTagline');
   let data = null;
   let round = 1;
+  let blur = 10;
 
   function updateProgress() {
     progress.style.width = (round / 7 * 100) + '%';
@@ -29,10 +32,28 @@ document.addEventListener('DOMContentLoaded', () => {
     const res = await fetch('/api/trivia/cast');
     data = await res.json();
     icons.innerHTML = '';
+    blur = 10;
+    if (posterImg) {
+      posterImg.style.filter = `blur(${blur}px)`;
+      posterImg.src = data.poster || '';
+    }
+    if (tagline) tagline.textContent = data.tagline || '';
     for (let i = 0; i < 7; i++) {
       const d = document.createElement('div');
       d.className = 'cast-circle';
-      d.textContent = i === 0 && data.cast.length > 0 ? data.cast[0] : '?';
+      if (i === 0 && data.cast.length > 0) {
+        if (data.cast[0].profile) {
+          const img = document.createElement('img');
+          img.src = data.cast[0].profile;
+          img.className = 'cast-img';
+          img.alt = data.cast[0].name;
+          d.appendChild(img);
+        } else {
+          d.textContent = data.cast[0].name;
+        }
+      } else {
+        d.textContent = '?';
+      }
       icons.appendChild(d);
     }
     updateProgress();
@@ -47,7 +68,23 @@ document.addEventListener('DOMContentLoaded', () => {
     } else {
       round++;
       if (round <= data.cast.length) {
-        document.querySelectorAll('.cast-circle')[round-1].textContent = data.cast[round-1];
+        const elem = document.querySelectorAll('.cast-circle')[round-1];
+        const castMember = data.cast[round-1];
+        if (castMember.profile) {
+          const img = document.createElement('img');
+          img.src = castMember.profile;
+          img.className = 'cast-img';
+          img.alt = castMember.name;
+          elem.textContent = '';
+          elem.appendChild(img);
+        } else {
+          elem.textContent = castMember.name;
+        }
+        if (blur > 0 && posterImg) {
+          blur -= 2;
+          if (blur < 0) blur = 0;
+          posterImg.style.filter = `blur(${blur}px)`;
+        }
         result.innerHTML = `<div class='alert alert-danger'>Try again!</div>`;
       } else {
         result.innerHTML = `<div class='alert alert-info'>Out of guesses. It was ${data.title}</div>`;

--- a/app/static/poster.js
+++ b/app/static/poster.js
@@ -3,6 +3,7 @@
 document.addEventListener('DOMContentLoaded', () => {
   const img = document.getElementById('posterImg');
   const summary = document.getElementById('posterSummary');
+  const tagline = document.getElementById('posterTagline');
   const revealBtn = document.getElementById('posterReveal');
   const result = document.getElementById('posterAnswer');
   const guessBtn = document.getElementById('guessBtn');
@@ -18,6 +19,7 @@ document.addEventListener('DOMContentLoaded', () => {
     if (data.poster) {
       img.src = data.poster;
     }
+    if (tagline) tagline.textContent = data.tagline || '';
     summary.textContent = data.summary.split(' ').slice(0, count).join(' ') + '...';
   }
 
@@ -55,6 +57,7 @@ document.addEventListener('DOMContentLoaded', () => {
       result.innerHTML = `<div class='alert alert-success'>Correct! It was ${data.title}</div>`;
       revealBtn.disabled = true;
       guessBtn.disabled = true;
+      img.style.filter = 'none';
     } else {
       result.innerHTML = `<div class='alert alert-danger'>Try again!</div>`;
     }

--- a/app/static/style.css
+++ b/app/static/style.css
@@ -109,6 +109,13 @@ body.dark-mode .card {
   font-weight: 600;
 }
 
+.cast-img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  border-radius: 50%;
+}
+
 .sidebar-bottom {
   margin-top: auto;
 }

--- a/app/static/year.js
+++ b/app/static/year.js
@@ -5,12 +5,19 @@ document.addEventListener('DOMContentLoaded', () => {
   const guessInput = document.getElementById('yearInput');
   const guessBtn = document.getElementById('yearGuess');
   const result = document.getElementById('yearResult');
+  const posterImg = document.getElementById('yearPoster');
+  const tagline = document.getElementById('yearTagline');
   let data = null;
 
   async function newQuestion() {
     const res = await fetch('/api/trivia/year');
     data = await res.json();
     question.textContent = `What year did ${data.title} release?`;
+    if (posterImg) {
+      posterImg.src = data.poster || '';
+      posterImg.style.filter = 'blur(5px)';
+    }
+    if (tagline) tagline.textContent = data.tagline || '';
     guessInput.value = '';
     result.textContent = '';
   }
@@ -19,6 +26,7 @@ document.addEventListener('DOMContentLoaded', () => {
     const guess = parseInt(guessInput.value, 10);
     if (guess === data.year) {
       result.innerHTML = `<span class='text-success'>Correct!</span>`;
+      if (posterImg) posterImg.style.filter = 'none';
     } else {
       result.innerHTML = `<span class='text-danger'>Nope, it was ${data.year}</span>`;
     }

--- a/app/templates/game_cast.html
+++ b/app/templates/game_cast.html
@@ -6,6 +6,8 @@
   <div class="progress mb-4" style="height:8px;">
     <div id="roundProgress" class="progress-bar" role="progressbar" aria-valuenow="1" aria-valuemin="0" aria-valuemax="7" style="width:14%"></div>
   </div>
+  <img id="moviePoster" class="mb-3" style="max-width:100%;filter:blur(10px);" />
+  <p id="movieTagline" class="mb-3"></p>
   <div id="castIcons" class="cast-icons"></div>
   <div class="input-group mb-3">
     <input id="guessInput" list="titleList" class="form-control" placeholder="Search titles">

--- a/app/templates/game_poster.html
+++ b/app/templates/game_poster.html
@@ -4,6 +4,7 @@
 <div class="game-container text-center">
   <h2 class="mb-4">Poster Reveal</h2>
   <img id="posterImg" style="max-width:100%;filter:blur(15px);" class="mb-3" />
+  <p id="posterTagline" class="mb-2"></p>
   <p id="posterSummary" class="mb-3"></p>
   <button id="posterReveal" class="btn btn-primary mb-3">Reveal More</button>
   <div class="input-group mb-3 w-50 mx-auto">

--- a/app/templates/game_year.html
+++ b/app/templates/game_year.html
@@ -3,6 +3,8 @@
 {% block content %}
 <div class="game-container text-center">
   <h2 class="mb-4" id="yearQuestion"></h2>
+  <img id="yearPoster" class="mb-3" style="max-width:100%;filter:blur(5px);" />
+  <p id="yearTagline" class="mb-3"></p>
   <div class="input-group mb-3 w-50 mx-auto">
     <input id="yearInput" class="form-control" placeholder="Enter year">
     <button class="btn btn-primary" id="yearGuess">Guess</button>

--- a/app/tmdb_service.py
+++ b/app/tmdb_service.py
@@ -20,6 +20,22 @@ class TMDbService:
             print(f"Failed to fetch movie details: {e}")
             return None
 
+    def get_movie_credits(self, movie_id: int):
+        """Return cast/crew information for a movie."""
+        if not self.client:
+            return None
+        try:
+            return self.client.movie(movie_id).credits()
+        except Exception as e:
+            print(f"Failed to fetch movie credits: {e}")
+            return None
+
+    def image_url(self, path: str | None, size: str = "w500") -> str | None:
+        """Return the full TMDb image URL for the given path."""
+        if not path:
+            return None
+        return f"https://image.tmdb.org/t/p/{size}{path}"
+
     def search_movies(self, query: str):
         """Search for movies by text query."""
         if not self.client:

--- a/app/trivia.py
+++ b/app/trivia.py
@@ -9,9 +9,9 @@ class TriviaEngine:
         self.tmdb = tmdb_service
 
     def _get_tmdb_details(self, movie):
-        """Return TMDb metadata for the given Plex movie."""
+        """Return (metadata, tmdb_id) for the given Plex movie."""
         if not self.tmdb:
-            return None
+            return None, None
 
         tmdb_id = None
         for guid in getattr(movie, "guids", []):
@@ -24,8 +24,9 @@ class TriviaEngine:
                 continue
 
         if tmdb_id:
-            return self.tmdb.get_movie_details(tmdb_id)
-        return None
+            details = self.tmdb.get_movie_details(tmdb_id)
+            return details, tmdb_id
+        return None, None
 
     def _random_movie(self):
         """Return a random movie from the Plex library."""
@@ -39,7 +40,7 @@ class TriviaEngine:
         if not movie:
             return None
         question = f"Which movie features '{movie}'?"
-        tmdb = self._get_tmdb_details(movie)
+        tmdb, _ = self._get_tmdb_details(movie)
         return {"question": question, "answer": movie, "tmdb": tmdb}
 
     def cast_reveal(self):
@@ -47,21 +48,46 @@ class TriviaEngine:
         movie = self._random_movie()
         if not movie:
             return None
-        try:
-            cast = [actor.tag for actor in movie.actors][:7]
-        except Exception:
-            cast = []
+        tmdb, tmdb_id = self._get_tmdb_details(movie)
+        cast = []
+        if tmdb_id:
+            credits = self.tmdb.get_movie_credits(tmdb_id)
+            if credits:
+                for c in credits.get("cast", [])[:7]:
+                    cast.append({
+                        "name": c.get("name"),
+                        "profile": self.tmdb.image_url(c.get("profile_path"), "w185"),
+                    })
+        if not cast:
+            try:
+                cast = [{"name": actor.tag, "profile": None} for actor in movie.actors][:7]
+            except Exception:
+                cast = []
 
-        tmdb = self._get_tmdb_details(movie)
-        return {"title": movie.title, "cast": cast, "tmdb": tmdb}
+        poster = self.tmdb.image_url(tmdb.get("poster_path")) if tmdb else None
+        tagline = tmdb.get("tagline") if tmdb else None
+        return {
+            "title": movie.title,
+            "cast": cast,
+            "poster": poster,
+            "tagline": tagline,
+        }
 
     def guess_year(self):
         """Return the title and year for a random movie."""
         movie = self._random_movie()
         if not movie:
             return None
-        tmdb = self._get_tmdb_details(movie)
-        return {"title": movie.title, "year": movie.year, "summary": movie.summary, "tmdb": tmdb}
+        tmdb, _ = self._get_tmdb_details(movie)
+        poster = self.tmdb.image_url(tmdb.get("poster_path")) if tmdb else None
+        tagline = tmdb.get("tagline") if tmdb else None
+        return {
+            "title": movie.title,
+            "year": movie.year,
+            "summary": movie.summary,
+            "poster": poster,
+            "tagline": tagline,
+        }
 
     def poster_reveal(self):
         """Return poster and summary information for a random movie."""
@@ -78,9 +104,13 @@ class TriviaEngine:
             except Exception:
                 poster = None
 
+        tmdb, _ = self._get_tmdb_details(movie)
+        if not poster and tmdb:
+            poster = self.tmdb.image_url(tmdb.get("poster_path"))
+        tagline = tmdb.get("tagline") if tmdb else None
         return {
             "title": movie.title,
             "poster": poster,
             "summary": movie.summary,
-            "tmdb": self._get_tmdb_details(movie),
+            "tagline": tagline,
         }


### PR DESCRIPTION
## Summary
- add TMDb helper methods for image urls and credits
- enrich trivia logic with posters, taglines and cast images
- display poster and tagline hints in templates
- show actor images and progressive poster reveal in JS
- style actor icons to support images

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6861b5027bd0833185997a1db9379cd9