### PR TITLE
Improve TMDb trivia hints and layout

### DIFF
--- a/app/static/cast.js
+++ b/app/static/cast.js
@@ -7,6 +7,8 @@ document.addEventListener('DOMContentLoaded', () => {
   const guessInput = document.getElementById('guessInput');
   const result = document.getElementById('result');
   const titleList = document.getElementById('titleList');
+  const posterImg = document.getElementById('castPoster');
+  const tagline = document.getElementById('castTagline');
   let data = null;
   let round = 1;
 
@@ -25,14 +27,37 @@ document.addEventListener('DOMContentLoaded', () => {
     });
   }
 
+  function setCast(el, info) {
+    el.innerHTML = '';
+    if (!info) {
+      el.textContent = '?';
+      return;
+    }
+    if (info.profile_path) {
+      const img = document.createElement('img');
+      img.src = 'https://image.tmdb.org/t/p/w185' + info.profile_path;
+      img.alt = info.name;
+      img.className = 'cast-img';
+      el.appendChild(img);
+    } else {
+      el.textContent = info.name || '?';
+    }
+  }
+
   async function initGame() {
     const res = await fetch('/api/trivia/cast');
     data = await res.json();
     icons.innerHTML = '';
+    posterImg.src = data.poster || '';
+    tagline.textContent = data.tagline || '';
     for (let i = 0; i < 7; i++) {
       const d = document.createElement('div');
       d.className = 'cast-circle';
-      d.textContent = i === 0 && data.cast.length > 0 ? data.cast[0] : '?';
+      if (i === 0) {
+        setCast(d, data.tmdb_cast[i] || {name: data.cast[i]});
+      } else {
+        setCast(d, null);
+      }
       icons.appendChild(d);
     }
     updateProgress();
@@ -46,8 +71,9 @@ document.addEventListener('DOMContentLoaded', () => {
       guessBtn.disabled = true;
     } else {
       round++;
-      if (round <= data.cast.length) {
-        document.querySelectorAll('.cast-circle')[round-1].textContent = data.cast[round-1];
+      if (round <= data.tmdb_cast.length || round <= data.cast.length) {
+        const info = data.tmdb_cast[round-1] || {name: data.cast[round-1]};
+        setCast(document.querySelectorAll('.cast-circle')[round-1], info);
         result.innerHTML = `<div class='alert alert-danger'>Try again!</div>`;
       } else {
         result.innerHTML = `<div class='alert alert-info'>Out of guesses. It was ${data.title}</div>`;

--- a/app/static/poster.js
+++ b/app/static/poster.js
@@ -3,6 +3,7 @@
 document.addEventListener('DOMContentLoaded', () => {
   const img = document.getElementById('posterImg');
   const summary = document.getElementById('posterSummary');
+  const tagline = document.getElementById('posterTagline');
   const revealBtn = document.getElementById('posterReveal');
   const result = document.getElementById('posterAnswer');
   const guessBtn = document.getElementById('guessBtn');
@@ -18,6 +19,7 @@ document.addEventListener('DOMContentLoaded', () => {
     if (data.poster) {
       img.src = data.poster;
     }
+    tagline.textContent = data.tagline || '';
     summary.textContent = data.summary.split(' ').slice(0, count).join(' ') + '...';
   }
 

--- a/app/static/style.css
+++ b/app/static/style.css
@@ -109,6 +109,13 @@ body.dark-mode .card {
   font-weight: 600;
 }
 
+.cast-img {
+  width: 100%;
+  height: 100%;
+  border-radius: 50%;
+  object-fit: cover;
+}
+
 .sidebar-bottom {
   margin-top: auto;
 }

--- a/app/static/year.js
+++ b/app/static/year.js
@@ -2,6 +2,7 @@
 
 document.addEventListener('DOMContentLoaded', () => {
   const question = document.getElementById('yearQuestion');
+  const tagline = document.getElementById('yearTagline');
   const guessInput = document.getElementById('yearInput');
   const guessBtn = document.getElementById('yearGuess');
   const result = document.getElementById('yearResult');
@@ -11,6 +12,7 @@ document.addEventListener('DOMContentLoaded', () => {
     const res = await fetch('/api/trivia/year');
     data = await res.json();
     question.textContent = `What year did ${data.title} release?`;
+    tagline.textContent = data.tagline || '';
     guessInput.value = '';
     result.textContent = '';
   }

--- a/app/templates/game_cast.html
+++ b/app/templates/game_cast.html
@@ -2,7 +2,9 @@
 
 {% block content %}
 <div class="game-container text-center">
-  <h2 class="mb-4">Cast Reveal</h2>
+  <h2 class="mb-2">Cast Reveal</h2>
+  <img id="castPoster" class="mb-2" style="max-height:300px;" />
+  <p id="castTagline" class="text-muted"></p>
   <div class="progress mb-4" style="height:8px;">
     <div id="roundProgress" class="progress-bar" role="progressbar" aria-valuenow="1" aria-valuemin="0" aria-valuemax="7" style="width:14%"></div>
   </div>

--- a/app/templates/game_poster.html
+++ b/app/templates/game_poster.html
@@ -2,7 +2,8 @@
 
 {% block content %}
 <div class="game-container text-center">
-  <h2 class="mb-4">Poster Reveal</h2>
+  <h2 class="mb-2">Poster Reveal</h2>
+  <p id="posterTagline" class="text-muted mb-2"></p>
   <img id="posterImg" style="max-width:100%;filter:blur(15px);" class="mb-3" />
   <p id="posterSummary" class="mb-3"></p>
   <button id="posterReveal" class="btn btn-primary mb-3">Reveal More</button>

--- a/app/templates/game_year.html
+++ b/app/templates/game_year.html
@@ -2,7 +2,8 @@
 
 {% block content %}
 <div class="game-container text-center">
-  <h2 class="mb-4" id="yearQuestion"></h2>
+  <h2 class="mb-2" id="yearQuestion"></h2>
+  <p id="yearTagline" class="text-muted mb-2"></p>
   <div class="input-group mb-3 w-50 mx-auto">
     <input id="yearInput" class="form-control" placeholder="Enter year">
     <button class="btn btn-primary" id="yearGuess">Guess</button>

--- a/app/tmdb_service.py
+++ b/app/tmdb_service.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from dataclasses import asdict, is_dataclass
 from themoviedb import TMDb
 
 
@@ -15,10 +16,23 @@ class TMDbService:
         if not self.client:
             return None
         try:
-            return self.client.movie(movie_id).details()
+            data = self.client.movie(movie_id).details(
+                options={"append_to_response": "credits"}
+            )
+            return self._to_dict(data)
         except Exception as e:
             print(f"Failed to fetch movie details: {e}")
             return None
+
+    def _to_dict(self, obj):
+        """Recursively convert TMDb dataclasses to plain dicts."""
+        if is_dataclass(obj):
+            return {k: self._to_dict(v) for k, v in asdict(obj).items()}
+        if isinstance(obj, list):
+            return [self._to_dict(v) for v in obj]
+        if isinstance(obj, dict):
+            return {k: self._to_dict(v) for k, v in obj.items()}
+        return obj
 
     def search_movies(self, query: str):
         """Search for movies by text query."""

--- a/app/trivia.py
+++ b/app/trivia.py
@@ -53,7 +53,30 @@ class TriviaEngine:
             cast = []
 
         tmdb = self._get_tmdb_details(movie)
-        return {"title": movie.title, "cast": cast, "tmdb": tmdb}
+        poster = None
+        tagline = None
+        tmdb_cast = []
+        if tmdb:
+            poster_path = tmdb.get("poster_path")
+            if poster_path:
+                poster = f"https://image.tmdb.org/t/p/w342{poster_path}"
+            tagline = tmdb.get("tagline")
+            credits = tmdb.get("credits", {})
+            for member in credits.get("cast", [])[:7]:
+                tmdb_cast.append(
+                    {
+                        "name": member.get("name"),
+                        "profile_path": member.get("profile_path"),
+                    }
+                )
+
+        return {
+            "title": movie.title,
+            "cast": cast,
+            "tmdb_cast": tmdb_cast,
+            "poster": poster,
+            "tagline": tagline,
+        }
 
     def guess_year(self):
         """Return the title and year for a random movie."""
@@ -61,7 +84,13 @@ class TriviaEngine:
         if not movie:
             return None
         tmdb = self._get_tmdb_details(movie)
-        return {"title": movie.title, "year": movie.year, "summary": movie.summary, "tmdb": tmdb}
+        tagline = tmdb.get("tagline") if tmdb else None
+        return {
+            "title": movie.title,
+            "year": movie.year,
+            "summary": movie.summary,
+            "tagline": tagline,
+        }
 
     def poster_reveal(self):
         """Return poster and summary information for a random movie."""
@@ -78,9 +107,20 @@ class TriviaEngine:
             except Exception:
                 poster = None
 
+        tmdb = self._get_tmdb_details(movie)
+        tagline = None
+        if tmdb:
+            poster_path = tmdb.get("poster_path")
+            if poster_path and not poster:
+                poster = f"https://image.tmdb.org/t/p/w342{poster_path}"
+            tagline = tmdb.get("tagline")
+            overview = tmdb.get("overview")
+            if not movie.summary and overview:
+                movie.summary = overview
+
         return {
             "title": movie.title,
             "poster": poster,
             "summary": movie.summary,
-            "tmdb": self._get_tmdb_details(movie),
+            "tagline": tagline,
         }


### PR DESCRIPTION
## Summary
- add recursive conversion for TMDb API results
- surface TMDb metadata in trivia engine for cast images and taglines
- show posters and taglines on trivia pages
- render actor images in Cast Reveal game
- style cast images

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6861b5027bd0833185997a1db9379cd9